### PR TITLE
Allow for `Set` to have a type class constraint

### DIFF
--- a/src/Axiom/Set.agda
+++ b/src/Axiom/Set.agda
@@ -50,172 +50,217 @@ Dec-SpecProperty = record
   ; sp-∩         = λ P? Q? _ → P? _ ×-dec Q? _
   }
 
-record Theory {ℓ} : Type (sucˡ ℓ) where
+-- Wrapper record enabling instance resolution for abstract constraint types.
+-- Agda's instance search requires the target to be a data/record type;
+-- wrapping `C A` in `Cstr C A` (a record) makes this work.
+record Cstr {ℓ ℓ_c} (C : Type ℓ → Type ℓ_c) (A : Type ℓ) : Type ℓ_c where
+  constructor mkCstr
+  field getCstr : C A
+open Cstr public
+
+record SetConstraint {ℓ ℓ_c} : Type (sucˡ (ℓ ⊔ˡ ℓ_c)) where
+  field constraint : Type ℓ → Type ℓ_c
+        c-×     : Cstr constraint A → Cstr constraint B → Cstr constraint (A × B)
+        c-Maybe : Cstr constraint A → Cstr constraint (Maybe A)
+
+⊤-SetConstraint : ∀ {ℓ} → SetConstraint {ℓ} {zeroˡ}
+⊤-SetConstraint = record
+  { constraint = λ _ → ⊤ ; c-× = λ _ _ → mkCstr tt
+  ; c-Maybe = λ _ → mkCstr tt }
+
+instance
+  Cstr-⊤ : ∀ {ℓ} {A : Type ℓ} → Cstr (λ _ → ⊤) A
+  Cstr-⊤ = mkCstr tt
+
+record Theory {ℓ} {ℓ_c} : Type (sucˡ (ℓ ⊔ˡ ℓ_c)) where
   infix 4 _⊆_ _≡ᵉ_ _∈_ _∉_
   infixr 6 _∪_
 
-  field Set : Type ℓ → Type ℓ
-        _∈_ : A → Set A → Type
-        sp  : SpecProperty
+  field sc : SetConstraint {ℓ} {ℓ_c}
+  open SetConstraint sc public
+
+  -- Short alias: Cs A = Cstr constraint A (the constraint for forming Set A)
+  Cs : Type ℓ → Type ℓ_c
+  Cs = Cstr constraint
+
+  field Set   : (A : Type ℓ) → ⦃ Cs A ⦄ → Type ℓ
+        _∈_   : ⦃ _ : Cs A ⦄ → A → Set A → Type
+        sp    : SpecProperty
+        c-Set : ⦃ _ : Cs A ⦄ → Cs (Set A)
   open SpecProperty sp public
 
-  _⊆_ : Set A → Set A → Type ℓ
+  instance
+    c-Set-instance : ⦃ _ : Cs A ⦄ → Cs (Set A)
+    c-Set-instance = c-Set
+
+    c-×-instance : ⦃ Cs A ⦄ → ⦃ Cs B ⦄ → Cs (A × B)
+    c-×-instance ⦃ ca ⦄ ⦃ cb ⦄ = c-× ca cb
+
+    c-Maybe-instance : ⦃ Cs A ⦄ → Cs (Maybe A)
+    c-Maybe-instance ⦃ ca ⦄ = c-Maybe ca
+
+  _⊆_ : ⦃ _ : Cs A ⦄ → Set A → Set A → Type ℓ
   X ⊆ Y = ∀ {a} → a ∈ X → a ∈ Y
 
   -- we might want to either have all properties or
   -- decidable properties allowed for specification
-  field specification : (X : Set A)
+  field specification : ⦃ _ : Cs A ⦄ → (X : Set A)
                       → specProperty P → ∃[ Y ] ∀ {a} → (P a × a ∈ X) ⇔ a ∈ Y
-        unions        : (X : Set (Set A))
+        unions        : ⦃ _ : Cs A ⦄ → (X : Set (Set A))
                       → ∃[ Y ] ∀ {a} → (∃[ T ] (T ∈ X × a ∈ T)) ⇔ a ∈ Y
-        replacement   : (f : A → B) (X : Set A)
+        replacement   : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → (f : A → B) (X : Set A)
                       → ∃[ Y ] ∀ {b} → (∃[ a ] b ≡ f a × a ∈ X) ⇔ b ∈ Y
-        listing       : (l : List A)
+        listing       : ⦃ _ : Cs A ⦄ → (l : List A)
                       → ∃[ X ] ∀ {a} → a ∈ˡ l ⇔ a ∈ X
                       -- ^ equivalent to pairing + empty set
         -- power-set     : (X : Set A) → ∃[ Y ] ∀ {T} → T ⊆ X → T ∈ Y
 
-  private variable X X' Y : Set A
-
-  _≡ᵉ_ : Set A → Set A → Type ℓ
+  _≡ᵉ_ : ⦃ _ : Cs A ⦄ → Set A → Set A → Type ℓ
   X ≡ᵉ Y = X ⊆ Y × Y ⊆ X
 
-  _≡ᵉ'_ : Set A → Set A → Type ℓ
+  _≡ᵉ'_ : ⦃ _ : Cs A ⦄ → Set A → Set A → Type ℓ
   X ≡ᵉ' Y = ∀ a → a ∈ X ⇔ a ∈ Y
 
-  _∉_ : A → Set A → Type
+  _∉_ : ⦃ _ : Cs A ⦄ → A → Set A → Type
   _∉_ = ¬_ ∘₂ _∈_
 
-  ≡→∈ : {X : Set A} {a a' : A} → a ∈ X → a ≡ a' → a' ∈ X
+  ≡→∈ : ⦃ _ : Cs A ⦄ → {X : Set A} {a a' : A} → a ∈ X → a ≡ a' → a' ∈ X
   ≡→∈ a∈X refl = a∈X
 
   -- The following is useful in case we have `(a , p)` and `(a , q)`, where `p`
   -- and `q` are proofs of `a ∈ X`, and we want to prove `(a , p) ≡ (a , q)`.
-  ∈-irrelevant : Set A → Type ℓ
+  ∈-irrelevant : ⦃ _ : Cs A ⦄ → Set A → Type ℓ
   ∈-irrelevant X = ∀ {a} (p q : a ∈ X) → p ≡ q
 
   open Equivalence
 
-  _Preservesˢ_ : (Set A → Set B) → (∀ {A} → Set A → Type) → Type ℓ
-  f Preservesˢ P = f Preserves₁ P ⟶ P
+  -- TODO: These need refactoring — instance resolution doesn't work in
+  -- higher-order type arguments. Move to Properties.agda or inline at use sites.
+  -- _Preservesˢ_ : ...
+  -- _Preservesˢ₂_ : ...
 
-  _Preservesˢ₂_ : (Set A → Set B → Set C) → (∀ {A : Type ℓ} → Set A → Type ℓ) → Type ℓ
-  f Preservesˢ₂ P = f Preserves₁₂ P ⟶ P ⟶ P
-
-  disjoint : Set A → Set A → Type ℓ
+  disjoint : ⦃ _ : Cs A ⦄ → Set A → Set A → Type ℓ
   disjoint X Y = ∀ {a} → a ∈ X → a ∈ Y → ⊥
 
-  finite : Set A → Type ℓ
+  finite : ⦃ _ : Cs A ⦄ → Set A → Type ℓ
   finite X = ∃[ l ] ∀ {a} → a ∈ X ⇔ a ∈ˡ l
 
-  Show-finite : ⦃ Show A ⦄ → Show (Σ (Set A) finite)
+  Show-finite : ⦃ _ : Cs A ⦄ → ⦃ Show A ⦄ → Show (Σ (Set A) finite)
   Show.show Show-finite (X , (l , _)) = Show-List .show l
 
-  weakly-finite : Set A → Type ℓ
+  weakly-finite : ⦃ _ : Cs A ⦄ → Set A → Type ℓ
   weakly-finite X = ∃[ l ] ∀ {a} → a ∈ X → a ∈ˡ l
 
   -- there exists a list without duplicates that has exactly the members of the set
-  strongly-finite : Set A → Type ℓ
+  strongly-finite : ⦃ _ : Cs A ⦄ → Set A → Type ℓ
   strongly-finite X = ∃[ l ] Unique l × ∀ {a} → a ∈ X ⇔ a ∈ˡ l
 
-  DecEq∧finite⇒strongly-finite : ⦃ _ : DecEq A ⦄ (X : Set A)
+  DecEq∧finite⇒strongly-finite : ⦃ _ : Cs A ⦄ → ⦃ _ : DecEq A ⦄ (X : Set A)
     → finite X → strongly-finite X
-  DecEq∧finite⇒strongly-finite ⦃ eq? ⦄ X (l , h) = let _≟_ = eq? ._≟_ in
+  DecEq∧finite⇒strongly-finite X (l , h) =
     deduplicate _≟_ l , deduplicate-! _≟_ l , λ {a} →
       a ∈ X                  ∼⟨ h ⟩
       a ∈ˡ l                 ∼⟨ ∈-dedup ⟩
       a ∈ˡ deduplicate _≟_ l ∎
     where open R.EquationalReasoning
 
-  card : Σ (Set A) strongly-finite → ℕ
+  card : ⦃ _ : Cs A ⦄ → Σ (Set A) strongly-finite → ℕ
   card (_ , l , _) = length l
 
-  ⊆-weakly-finite : X ⊆ Y → weakly-finite Y → weakly-finite X
+  ⊆-weakly-finite : ⦃ _ : Cs A ⦄ → {X Y : Set A}
+    → X ⊆ Y → weakly-finite Y → weakly-finite X
   ⊆-weakly-finite X⊆Y (l , hl) = l , hl ∘ X⊆Y
 
-  isMaximal : Set A → Type ℓ
+  isMaximal : ⦃ _ : Cs A ⦄ → Set A → Type ℓ
   isMaximal {A} X = {a : A} → a ∈ X
 
-  maximal-⊆ : isMaximal Y → X ⊆ Y
+  maximal-⊆ : ⦃ _ : Cs A ⦄ → {X Y : Set A} → isMaximal Y → X ⊆ Y
   maximal-⊆ maxY _ = maxY
 
-  maximal-unique : isMaximal X → isMaximal Y → X ≡ᵉ Y
+  maximal-unique : ⦃ _ : Cs A ⦄ → {X Y : Set A} → isMaximal X → isMaximal Y → X ≡ᵉ Y
   maximal-unique maxX maxY = maximal-⊆ maxY , maximal-⊆ maxX
 
-  FinSet : Type ℓ → Type ℓ
+  FinSet : (A : Type ℓ) → ⦃ _ : Cs A ⦄ → Type ℓ
   FinSet A = Σ (Set A) finite
 
   -- if you can construct a set that contains all elements satisfying
   -- P, you can construct a set containing exactly the elements satisfying P
-  strictify : specProperty P → (∃[ Y ] ∀ {a} → P a → a ∈ Y) → ∃[ Y ] ∀ {a} → P a ⇔ a ∈ Y
+  strictify : ⦃ _ : Cs A ⦄ → specProperty P
+    → (Σ (Set A) λ Y → ∀ {a} → P a → a ∈ Y) → Σ (Set A) λ Y → ∀ {a} → P a ⇔ a ∈ Y
   strictify sp p with specification (proj₁ p) sp
   ... | (Y , p') = Y , (mk⇔ (λ a∈l → to p' (a∈l , proj₂ p a∈l)) (proj₁ ∘ from p'))
 
-  map : (A → B) → Set A → Set B
+  map : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → (A → B) → Set A → Set B
   map = proj₁ ∘₂ replacement
 
-  ∈-map : ∀ {f : A → B} {b} → (∃[ a ] b ≡ f a × a ∈ X) ⇔ b ∈ map f X
+  ∈-map : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → ∀ {f : A → B} {b} {X : Set A}
+    → (∃[ a ] b ≡ f a × a ∈ X) ⇔ b ∈ map f X
   ∈-map = proj₂ $ replacement _ _
 
-  ∈-map′ : ∀ {f : A → B} {a} → a ∈ X → f a ∈ map f X
+  ∈-map′ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → ∀ {f : A → B} {a} {X : Set A}
+    → a ∈ X → f a ∈ map f X
   ∈-map′ {a = a} a∈X = to ∈-map (a , refl , a∈X)
 
   -- don't know that there's a set containing all members of a type, which this is equivalent to
   -- _⁻¹_ : (A → B) → Set B → Set A
   -- f ⁻¹ X = {!!}
 
-  filter : {P : A → Type} → specProperty P → Set A → Set A
+  filter : ⦃ _ : Cs A ⦄ → {P : A → Type} → specProperty P → Set A → Set A
   filter = proj₁ ∘₂ flip specification
 
-  ∈-filter : ∀ {sp-P : specProperty P} {a} → (P a × a ∈ X) ⇔ a ∈ filter sp-P X
+  ∈-filter : ⦃ _ : Cs A ⦄ → ∀ {sp-P : specProperty P} {a} {X : Set A}
+    → (P a × a ∈ X) ⇔ a ∈ filter sp-P X
   ∈-filter = proj₂ $ specification _ _
 
-  fromList : List A → Set A
+  fromList : ⦃ _ : Cs A ⦄ → List A → Set A
   fromList = proj₁ ∘ listing
 
-  ∈-fromList : ∀ {a} → a ∈ˡ l ⇔ a ∈ fromList l
+  ∈-fromList : ⦃ _ : Cs A ⦄ → ∀ {a} {l : List A} → a ∈ˡ l ⇔ a ∈ fromList l
   ∈-fromList = proj₂ $ listing _
 
-  ∈-unions : {a : A} {U : Set (Set A)} → (∃[ T ] T ∈ U × a ∈ T) ⇔ a ∈ proj₁ (unions U)
+  ∈-unions : ⦃ _ : Cs A ⦄ → {a : A} {U : Set (Set A)}
+    → (∃[ T ] T ∈ U × a ∈ T) ⇔ a ∈ proj₁ (unions U)
   ∈-unions = proj₂ $ unions _
 
-  ∅ : Set A
+  ∅ : ⦃ _ : Cs A ⦄ → Set A
   ∅ = fromList []
 
-  ∅-strongly-finite : strongly-finite {A} ∅
+  ∅-strongly-finite : ⦃ _ : Cs A ⦄ → strongly-finite {A} ∅
   ∅-strongly-finite = [] , [] , R.SK-sym ∈-fromList
 
-  card-∅ : card (∅ {A} , ∅-strongly-finite) ≡ 0
+  card-∅ : ⦃ _ : Cs A ⦄ → card (∅ {A} , ∅-strongly-finite) ≡ 0
   card-∅ = refl
 
-  singleton : A → Set A
+  singleton : ⦃ _ : Cs A ⦄ → A → Set A
   singleton a = fromList [ a ]
 
   ❴_❵ = singleton
 
-  ∈-singleton : {a b : A} → a ≡ b ⇔ a ∈ singleton b
+  ∈-singleton : ⦃ _ : Cs A ⦄ → {a b : A} → a ≡ b ⇔ a ∈ singleton b
   ∈-singleton {_} {a} {b} =
     a ≡ b           ∼⟨ mk⇔ (λ where refl → here refl) (λ where (here refl) → refl) ⟩
     a ∈ˡ [ b ]      ∼⟨ ∈-fromList ⟩
     a ∈ singleton b ∎
     where open R.EquationalReasoning
 
-  partialToSet : (A → Maybe B) → A → Set B
+  partialToSet : ⦃ _ : Cs B ⦄ → (A → Maybe B) → A → Set B
   partialToSet f a = maybe (fromList ∘ [_]) ∅ (f a)
 
-  ∈-partialToSet : ∀ {a : A} {b : B} {f} → f a ≡ just b ⇔ b ∈ partialToSet f a
+  ∈-partialToSet : ⦃ _ : Cs B ⦄ → ∀ {a : A} {b : B} {f}
+    → f a ≡ just b ⇔ b ∈ partialToSet f a
   ∈-partialToSet {a = a} {b} {f} = mk⇔
     (λ h → subst (λ x → b ∈ maybe (fromList ∘ [_]) ∅ x) (sym h) (to ∈-singleton refl))
     (case f a returning (λ y → b ∈ maybe (λ x → fromList [ x ]) ∅ y → y ≡ just b) of
       λ where (just x) → λ h → cong just (sym $ from ∈-singleton h)
               nothing  → λ h → case from ∈-fromList h of λ ())
 
-  concatMapˢ : (A → Set B) → Set A → Set B
+  concatMapˢ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → (A → Set B) → Set A → Set B
   concatMapˢ f a = proj₁ $ unions (map f a)
 
-  ∈-concatMapˢ : {y : B} {f : A → Set B}
+  ∈-concatMapˢ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄
+    → {y : B} {f : A → Set B} {X : Set A}
     → (∃[ x ] x ∈ X × y ∈ f x) ⇔ y ∈ concatMapˢ f X
-  ∈-concatMapˢ {X = X} {y} {f} =
+  ∈-concatMapˢ {y = y} {f} {X} =
     (∃[ x ] x ∈ X × y ∈ f x)
       ∼⟨ ∃-cong′ (λ {x} → ∃-≡ (λ T → x ∈ X × y ∈ T)) ⟩
     (∃[ x ] ∃[ T ] T ≡ f x × x ∈ X × y ∈ T)
@@ -231,12 +276,13 @@ record Theory {ℓ} : Type (sucˡ ℓ) where
     y ∈ concatMapˢ f X ∎
     where open R.EquationalReasoning
 
-  mapPartial : (A → Maybe B) → Set A → Set B
+  mapPartial : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → (A → Maybe B) → Set A → Set B
   mapPartial f = concatMapˢ (partialToSet f)
 
-  ∈-mapPartial : {y : B} {f : A → Maybe B}
+  ∈-mapPartial : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄
+    → {y : B} {f : A → Maybe B} {X : Set A}
     → (∃[ x ] x ∈ X × f x ≡ just y) ⇔ y ∈ mapPartial f X
-  ∈-mapPartial {X = X} {y} {f} =
+  ∈-mapPartial {y = y} {f} {X} =
     (∃[ x ] x ∈ X × f x ≡ just y)
       ∼⟨ ∃-cong′ (R.K-refl ×-cong (∈-partialToSet {f = f})) ⟩
     (∃[ x ] x ∈ X × y ∈ partialToSet f x)
@@ -244,12 +290,14 @@ record Theory {ℓ} : Type (sucˡ ℓ) where
     y ∈ mapPartial f X ∎
     where open R.EquationalReasoning
 
-  ⊆-mapPartial : ∀ {f : A → Maybe B} → map just (mapPartial f X) ⊆ map f X
+  ⊆-mapPartial : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄
+    → ∀ {f : A → Maybe B} {X : Set A} → map just (mapPartial f X) ⊆ map f X
   ⊆-mapPartial {f = f} a∈m with from ∈-map a∈m
   ... | x , refl , a∈mp with from (∈-mapPartial {f = f}) a∈mp
   ... | x' , x'∈X , jx≡fx = to ∈-map (x' , sym jx≡fx , x'∈X)
 
-  binary-unions : ∃[ Y ] ∀ {a} → (a ∈ X ⊎ a ∈ X') ⇔ a ∈ Y
+  binary-unions : ⦃ _ : Cs A ⦄ → {X X' : Set A}
+    → ∃[ Y ] ∀ {a} → (a ∈ X ⊎ a ∈ X') ⇔ a ∈ Y
   binary-unions {X = X} {X'} with unions (fromList (X ∷ [ X' ]))
   ... | (Y , h) = Y , mk⇔ (λ where
     (inj₁ a∈X)  → to h (X  , to ∈-fromList (here refl)         , a∈X)
@@ -258,24 +306,24 @@ record Theory {ℓ} : Type (sucˡ ℓ) where
       (here refl) → inj₁ a∈T
       (there (here refl)) → inj₂ a∈T)
 
-  _∪_ : Set A → Set A → Set A
+  _∪_ : ⦃ _ : Cs A ⦄ → Set A → Set A → Set A
   X ∪ Y = proj₁ binary-unions
 
-  ∈-∪ : ∀ {a} → (a ∈ X ⊎ a ∈ Y) ⇔ a ∈ X ∪ Y
+  ∈-∪ : ⦃ _ : Cs A ⦄ → ∀ {a} {X Y : Set A} → (a ∈ X ⊎ a ∈ Y) ⇔ a ∈ X ∪ Y
   ∈-∪ = proj₂ binary-unions
 
-  spec-∈ : Type ℓ → Type ℓ
+  spec-∈ : (A : Type ℓ) → ⦃ _ : Cs A ⦄ → Type ℓ
   spec-∈ A = {X : Set A} → specProperty (_∈ X)
 
   -- membership needs to be a specProperty to have intersections
-  module Intersection (sp-∈ : spec-∈ A) where
+  module Intersection ⦃ _ : Cs A ⦄ (sp-∈ : spec-∈ A) where
 
     infixr 7 _∩_
     _∩_ : Set A → Set A → Set A
     X ∩ Y = filter sp-∈ X
 
-    ∈-∩ : ∀ {a} → (a ∈ X × a ∈ Y) ⇔ a ∈ X ∩ Y
-    ∈-∩ {X} {Y} {a} = (a ∈ X × a ∈ Y) ↔⟨ ×-comm _ _ ⟩
+    ∈-∩ : ∀ {a} {X Y : Set A} → (a ∈ X × a ∈ Y) ⇔ a ∈ X ∩ Y
+    ∈-∩ {a = a} {X} {Y} = (a ∈ X × a ∈ Y) ↔⟨ ×-comm _ _ ⟩
                       (a ∈ Y × a ∈ X) ∼⟨ ∈-filter ⟩
                       a ∈ X ∩ Y       ∎
       where open R.EquationalReasoning
@@ -286,54 +334,55 @@ record Theory {ℓ} : Type (sucˡ ℓ) where
     _＼_ : Set A → Set A → Set A
     X ＼ Y = filter (sp-¬ (sp-∈ {Y})) X
 
-  All : (A → Type) → Set A → Type ℓ
+  All : ⦃ _ : Cs A ⦄ → (A → Type) → Set A → Type ℓ
   All P X = ∀ {a} → a ∈ X → P a
 
-  Any : (A → Type) → Set A → Type ℓ
+  Any : ⦃ _ : Cs A ⦄ → (A → Type) → Set A → Type ℓ
   Any P X = ∃[ a ] a ∈ X × P a
 
 -- finite set theories
-record Theoryᶠ : Type₁ where
-  field theory : Theory
+record Theoryᶠ {ℓ_c} : Type (sucˡ ℓ_c) where
+  field theory : Theory {zeroˡ} {ℓ_c}
   open Theory theory public
 
-  field finiteness : (X : Set A) → finite X
+  field finiteness : ⦃ _ : Cs A ⦄ → (X : Set A) → finite X
 
-  DecEq⇒strongly-finite : ⦃ DecEq A ⦄ → (X : Set A) → strongly-finite X
+  DecEq⇒strongly-finite : ⦃ _ : Cs A ⦄ → ⦃ DecEq A ⦄ → (X : Set A) → strongly-finite X
   DecEq⇒strongly-finite X = DecEq∧finite⇒strongly-finite X (finiteness X)
 
-  toList : ⦃ DecEq A ⦄ → Set A → List A
+  toList : ⦃ _ : Cs A ⦄ → ⦃ DecEq A ⦄ → Set A → List A
   toList = proj₁ ∘ DecEq⇒strongly-finite
 
-  lengthˢ : ⦃ DecEq A ⦄ → Set A → ℕ
+  lengthˢ : ⦃ _ : Cs A ⦄ → ⦃ DecEq A ⦄ → Set A → ℕ
   lengthˢ X = card (X , DecEq⇒strongly-finite X)
 
-  module _ {A : Type} ⦃ _ : Show A ⦄ where
+  module _ {A : Type} ⦃ _ : Cs A ⦄ ⦃ _ : Show A ⦄ where
     instance
       Show-Set : Show (Set A)
       Show-Set .show = λ x → Show-finite .show (x , (finiteness x))
 
 -- set theories with an infinite set (containing all natural numbers)
-record Theoryⁱ : Type₁ where
-  field theory : Theory
+record Theoryⁱ {ℓ_c} : Type (sucˡ ℓ_c) where
+  field theory : Theory {zeroˡ} {ℓ_c}
   open Theory theory public
 
-  field infinity : ∃[ Y ] ((n : ℕ) → n ∈ Y)
+  field ⦃ c-ℕ ⦄ : Cstr constraint ℕ
+        infinity : ∃[ Y ] ((n : ℕ) → n ∈ Y)
 
 -- theories with decidable properties
-record Theoryᵈ : Type₁ where
-  field th : Theory
+record Theoryᵈ {ℓ_c} : Type (sucˡ ℓ_c) where
+  field th : Theory {zeroˡ} {ℓ_c}
   open Theory th public
   open Equivalence
 
   field
-    ∈-sp : ⦃ DecEq A ⦄ → spec-∈ A
-    _∈?_ : ⦃ DecEq A ⦄ → Decidable² (_∈_ {A = A})
-    all? : {P : A → Type} (P? : Decidable¹ P) {X : Set A} → Dec (All P X)
-    any? : {P : A → Type} (P? : Decidable¹ P) (X : Set A) → Dec (Any P X)
+    ∈-sp : ⦃ _ : Cs A ⦄ → ⦃ DecEq A ⦄ → spec-∈ A
+    _∈?_ : ⦃ _ : Cs A ⦄ → ⦃ DecEq A ⦄ → Decidable² (_∈_ {A = A})
+    all? : ⦃ _ : Cs A ⦄ → {P : A → Type} (P? : Decidable¹ P) {X : Set A} → Dec (All P X)
+    any? : ⦃ _ : Cs A ⦄ → {P : A → Type} (P? : Decidable¹ P) (X : Set A) → Dec (Any P X)
 
 
-  module _ {A : Type} {P : A → Type} where
+  module _ {A : Type} ⦃ _ : Cs A ⦄ {P : A → Type} where
     module _ ⦃ _ : P ⁇¹ ⦄ where instance
       Dec-Allˢ : All P ⁇¹
       Dec-Allˢ = ⁇¹ λ x → all? dec¹ {x}
@@ -346,7 +395,7 @@ record Theoryᵈ : Type₁ where
       allᵇ X = ⌊ all? P? {X} ⌋
       anyᵇ X = ⌊ any? P? X   ⌋
 
-  module _ {A : Type} ⦃ _ : DecEq A ⦄ where
+  module _ {A : Type} ⦃ _ : Cs A ⦄ ⦃ _ : DecEq A ⦄ where
 
     _∈ᵇ_ : A → Set A → Bool
     a ∈ᵇ X = ⌊ a ∈? X ⌋
@@ -364,10 +413,10 @@ record Theoryᵈ : Type₁ where
     ... | yes p = just (x , p)
     ... | no  p = nothing
 
-    incl-set : (X : Set A) → Set (∃[ a ] a ∈ X)
+    incl-set : (X : Set A) → ⦃ _ : Cstr constraint (∃[ a ] a ∈ X) ⦄ → Set (∃[ a ] a ∈ X)
     incl-set X = mapPartial (incl-set' X) X
 
-    module _ {X : Set A} where
+    module _ {X : Set A} ⦃ _ : Cstr constraint (∃[ a ] a ∈ X) ⦄ where
       incl-set-proj₁⊆ : map proj₁ (incl-set X) ⊆ X
       incl-set-proj₁⊆ x with from ∈-map x
       ... | (_ , pf) , refl , _ = pf

--- a/src/Axiom/Set/Factor.agda
+++ b/src/Axiom/Set/Factor.agda
@@ -1,9 +1,9 @@
 {-# OPTIONS --safe --no-import-sorts #-}
 
 open import abstract-set-theory.Prelude
-open import Axiom.Set
+open import Axiom.Set using (Theory)
 
-module Axiom.Set.Factor (th : Theory) where
+module Axiom.Set.Factor {ℓ} {ℓ_c} (th : Theory {ℓ} {ℓ_c}) where
 
 open Theory th
 open import Axiom.Set.Properties th
@@ -20,16 +20,16 @@ open import Relation.Binary
 
 open Equivalence
 
-private variable A B : Type
+private variable A B : Type ℓ
 
-_ᶠ : (X : Set A) → ⦃ finite X ⦄ → FinSet A
+_ᶠ : ⦃ _ : Cs A ⦄ → (X : Set A) → ⦃ finite X ⦄ → FinSet A
 _ᶠ X ⦃ Xᶠ ⦄ = X , Xᶠ
 
 instance
-  ∪-preserves-finite' : {X Y : Set A} → ⦃ finite X ⦄ → ⦃ finite Y ⦄ → finite (X ∪ Y)
-  ∪-preserves-finite' ⦃ Xᶠ ⦄ ⦃ Yᶠ ⦄ = ∪-preserves-finite Xᶠ Yᶠ
+  ∪-preserves-finite' : ⦃ _ : Cs A ⦄ → {X Y : Set A} → ⦃ finite X ⦄ → ⦃ finite Y ⦄ → finite (X ∪ Y)
+  ∪-preserves-finite' ⦃ _ ⦄ ⦃ Xᶠ ⦄ ⦃ Yᶠ ⦄ = ∪-preserves-finite Xᶠ Yᶠ
 
-module Factor (_≈_ : B → B → Type) (f : List A → B) (f-cong : ∀ {l l'} → l ∼[ set ] l' → f l ≈ f l') where
+module Factor ⦃ _ : Cs A ⦄ (_≈_ : B → B → Type) (f : List A → B) (f-cong : ∀ {l l'} → l ∼[ set ] l' → f l ≈ f l') where
 
   factor : FinSet A → B
   factor (_ , l , _) = f l
@@ -45,7 +45,7 @@ module Factor (_≈_ : B → B → Type) (f : List A → B) (f-cong : ∀ {l l'}
            → R (factor (X ᶠ)) (factor (Y ᶠ)) (factor ((X ∪ Y) ᶠ))
   factor-∪ hR = hR
 
-module FactorUnique ⦃ _ : DecEq A ⦄ (_≈_ : B → B → Type) (f : (Σ (List A) Unique) → B)
+module FactorUnique ⦃ _ : Cs A ⦄ ⦃ _ : DecEq A ⦄ (_≈_ : B → B → Type) (f : (Σ (List A) Unique) → B)
                     (f-cong : ∀ {l l'} → proj₁ l ↭ proj₁ l' → f l ≈ f l') where
 
   f-cong' : ∀ {l l'} → (∀ {a} → a ∈ˡ proj₁ l ⇔ a ∈ˡ proj₁ l') → f l ≈ f l'

--- a/src/Axiom/Set/List.agda
+++ b/src/Axiom/Set/List.agda
@@ -22,9 +22,11 @@ open import Relation.Nullary.Decidable
 
 List-Model : Theory
 List-Model = λ where
-  .Set           → List
+  .sc            → ⊤-SetConstraint
+  .Set           → λ _ → List _
   ._∈_           → _∈ˡ_
   .sp            → Dec-SpecProperty
+  .c-Set         → mkCstr tt
   .specification → λ X P? → filter P? X , mk⇔
     (λ where (Pa , a∈X) → ∈-filter⁺ P? a∈X Pa)
     (λ a∈f → swap (∈-filter⁻ P? a∈f))

--- a/src/Axiom/Set/Map.agda
+++ b/src/Axiom/Set/Map.agda
@@ -4,7 +4,7 @@
 open import abstract-set-theory.Prelude
 open import Axiom.Set using (Theory)
 
-module Axiom.Set.Map (th : Theory) where
+module Axiom.Set.Map {ℓ} {ℓ_c} (th : Theory {ℓ} {ℓ_c}) where
 
 open Theory th renaming (map to mapˢ)
 
@@ -40,68 +40,65 @@ private
       ∷ quote ∈-filter⁺' ∷ quote ∈-∪⁺ ∷ quote ∈-map⁺' ∷ quote ∈-fromList⁺ ∷ [])
 
   variable
-    A A' B B' C D : Type
-    R R' : Rel A B
-    X Y : Set A
-    a : A
-    a' : A'
-    b : B
-    b' : B'
+    A A' B B' C D : Type ℓ
 
   ×-dup : ∀ {ℓ} {A : Type ℓ} → A → A × A
   ×-dup x = x , x
 
-left-unique : Rel A B → Type
+left-unique : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → Rel A B → Type ℓ
 left-unique R = ∀ {a b b'} → (a , b) ∈ R → (a , b') ∈ R → b ≡ b'
 
-record IsLeftUnique (R : Rel A B) : Type where
+record IsLeftUnique ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄ (R : Rel A B) : Type ℓ where
   field isLeftUnique : left-unique R
 
 instance
-  ∅-left-unique : IsLeftUnique {A = A} {B = B} ∅
+  ∅-left-unique : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → IsLeftUnique {A = A} {B = B} ∅
   ∅-left-unique .IsLeftUnique.isLeftUnique h h' = ⊥-elim $ ∉-∅ h
 
-⊆-left-unique : R ⊆ R' → left-unique R' → left-unique R
+⊆-left-unique : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄
+  → {R R' : Rel A B} → R ⊆ R' → left-unique R' → left-unique R
 ⊆-left-unique R⊆R' h = R⊆R' -⟨ h ⟩- R⊆R' -- on isn't dependent enough
 
-left-unique-mapˢ : {f : A → B} (X : Set A) → left-unique (mapˢ (λ y → (y , f y)) X)
+left-unique-mapˢ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄
+  → {f : A → B} (X : Set A) → left-unique (mapˢ (λ y → (y , f y)) X)
 left-unique-mapˢ _ p q with from ∈-map p | from ∈-map q
 ... | _ , refl , _ | _ , refl , _ = refl
 
-Map : Type → Type → Type
+Map : (A B : Type ℓ) → ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → Type ℓ
 Map A B = Σ (Rel A B) left-unique
 
 infix 4 _≡ᵐ_
 
-_≡ᵐ_ : Map A B → Map A B → Type
+_≡ᵐ_ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → Map A B → Map A B → Type ℓ
 (x , _) ≡ᵐ (y , _) = x ≡ᵉ y
 
 infix 4 _≢ᵐ_
 
-_≢ᵐ_ : Map A B → Map A B → Type
+_≢ᵐ_ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → Map A B → Map A B → Type ℓ
 a ≢ᵐ b = ¬ a ≡ᵐ b
 
-private variable m m' : Map A B
-
-_ˢ : Map A B → Rel A B
+_ˢ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → Map A B → Rel A B
 _ˢ = proj₁
 
-_ᵐ : (R : Rel A B) → ⦃ IsLeftUnique R ⦄ → Map A B
+_ᵐ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄
+  → (R : Rel A B) → ⦃ IsLeftUnique R ⦄ → Map A B
 _ᵐ R ⦃ record { isLeftUnique = h } ⦄ = R , h
 
-⊆-map : (f : Rel A B → Rel A B) → (∀ {R} → f R ⊆ R) → Map A B → Map A B
+⊆-map : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄
+  → (f : Rel A B → Rel A B) → (∀ {R} → f R ⊆ R) → Map A B → Map A B
 ⊆-map f H m = f (m ˢ) , ⊆-left-unique H (proj₂ m)
 
-ˢ-left-unique : IsLeftUnique (m ˢ)
+ˢ-left-unique : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄
+  → {m : Map A B} → IsLeftUnique (m ˢ)
 ˢ-left-unique {m = m} = record { isLeftUnique = proj₂ m }
 
 instance
   _ = ˢ-left-unique
 
-∅ᵐ : Map A B
+∅ᵐ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → Map A B
 ∅ᵐ = _ᵐ ∅ ⦃ ∅-left-unique ⦄
 
-fromListᵐ : ⦃ _ : DecEq A ⦄ → List (A × B) → Map A B
+fromListᵐ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → ⦃ _ : DecEq A ⦄ → List (A × B) → Map A B
 fromListᵐ l = fromList (deduplicate (λ x y → proj₁ x ≟ proj₁ y) l) ,
   (λ where (inj₁ refl)     → refl
            (inj₂ (inj₁ x)) → ⊥-elim (x refl)
@@ -111,43 +108,47 @@ fromListᵐ l = fromList (deduplicate (λ x y → proj₁ x ≟ proj₁ y) l) ,
   where open import Data.List.Relation.Unary.Unique.DecSetoid.Properties
         import Relation.Binary.Construct.On as On
 
-FinMap : Type → Type → Type
+FinMap : (A B : Type ℓ) → ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → Type ℓ
 FinMap A B = Σ (Rel A B) (λ R → left-unique R × finite R)
 
-toFinMap : (m : Map A B) → finite (m ˢ) → FinMap A B
+toFinMap : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄
+  → (m : Map A B) → finite (m ˢ) → FinMap A B
 toFinMap (m , h) fin = m , h , fin
 
-toMap : FinMap A B → Map A B
+toMap : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → FinMap A B → Map A B
 toMap (m , l , _) = m , l
 
-toRel : FinMap A B → Rel A B
+toRel : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → FinMap A B → Rel A B
 toRel (m , l , _) = m
 
-module Intersectionᵐ (sp-∈ : spec-∈ (A × B)) where
+module Intersectionᵐ ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄ (sp-∈ : spec-∈ (A × B)) where
   open Intersection sp-∈
   open Intersectionᵖ sp-∈
 
   _∩ᵐ_ : Map A B → Map A B → Map A B
   m ∩ᵐ m' = (m ˢ ∩ m' ˢ , ⊆-left-unique ∩-⊆ˡ (proj₂ m))
 
-disj-∪ : (m m' : Map A B) → disjoint (dom (m ˢ)) (dom (m' ˢ)) → Map A B
+disj-∪ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄
+  → (m m' : Map A B) → disjoint (dom (m ˢ)) (dom (m' ˢ)) → Map A B
 disj-∪ m m' disj = m ˢ ∪ m' ˢ , λ h h' → case ∈-∪⁻ h , ∈-∪⁻ h' of λ where
   (inj₁ hm  , inj₁ h'm)  → proj₂ m hm h'm
   (inj₂ hm' , inj₁ h'm)  → ⊥-elim $ disj (∈-map⁺'' h'm) (∈-map⁺'' hm')
   (inj₁ hm  , inj₂ h'm') → ⊥-elim $ disj (∈-map⁺'' hm)  (∈-map⁺'' h'm')
   (inj₂ hm' , inj₂ h'm') → proj₂ m' hm' h'm'
 
-disj-∪-cong : {m m' m'' m''' : Map A B}
+disj-∪-cong : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄
+              → {m m' m'' m''' : Map A B}
               {m∩m'≡∅ : disjoint (dom (m ˢ)) (dom (m' ˢ))}
               {m''∩m'''≡∅ : disjoint (dom (m'' ˢ)) (dom (m''' ˢ))}
               → m ≡ᵐ m'' → m' ≡ᵐ m'''
               → disj-∪ m m' m∩m'≡∅ ≡ᵐ disj-∪ m'' m''' m''∩m'''≡∅
 disj-∪-cong m≡m' m''≡m''' = ∪-cong m≡m' m''≡m'''
 
-filterᵐ : {P : Pred (A × B) 0ℓ} → specProperty P → Map A B → Map A B
+filterᵐ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄
+  → {P : Pred (A × B) 0ℓ} → specProperty P → Map A B → Map A B
 filterᵐ sp-P m = filter sp-P (m ˢ) , ⊆-left-unique filter-⊆ (proj₂ m)
 
-module _ {P : Pred (A × B) 0ℓ} {spP : specProperty P} where
+module _ ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄ {P : Pred (A × B) 0ℓ} {spP : specProperty P} where
   filterᵐ-idem : ∀ {m : Map A B} → filterᵐ spP (filterᵐ spP m) ≡ᵐ filterᵐ spP m
   filterᵐ-idem = filter-idem
 
@@ -163,21 +164,24 @@ module _ {P : Pred (A × B) 0ℓ} {spP : specProperty P} where
       filterᵐspPm⊇filterᵐspPm' p with from ∈-filter p
       ... | (q , p) = to ∈-filter (q , proj₂ m≡m' p)
 
-filterᵐ-finite : {P : A × B → Type} → (sp : specProperty P) → Decidable P
+filterᵐ-finite : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄
+  → {m : Map A B} {P : A × B → Type} → (sp : specProperty P) → Decidable P
   → finite (m ˢ) → finite (filterᵐ sp m ˢ)
 filterᵐ-finite = filter-finite
 
-filterKeys : {P : A → Type} → specProperty P → Map A B → Map A B
+filterKeys : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄
+  → {P : A → Type} → specProperty P → Map A B → Map A B
 filterKeys sp-P = filterᵐ (sp-∘ sp-P proj₁)
 
-singletonᵐ : A → B → Map A B
+singletonᵐ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → A → B → Map A B
 singletonᵐ a b = ❴ (a , b) ❵
                , (from ∈-singleton -⟨ (λ where refl refl → refl) ⟩- from ∈-singleton)
 
-❴_❵ᵐ : A × B → Map A B
+❴_❵ᵐ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → A × B → Map A B
 ❴ k , v ❵ᵐ = singletonᵐ k v
 
-disj-dom : ∀ {m m₁ m₂ : Map A B}
+disj-dom : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄
+  → ∀ {m m₁ m₂ : Map A B}
   → (m ˢ) ≡ (m₁ ˢ) ⨿ (m₂ ˢ)
   → disjoint (dom (m₁ ˢ)) (dom (m₂ ˢ))
 disj-dom {m = m@(_ , uniq)} {m₁} {m₂} (m≡m₁∪m₂ , disj) a∈domm₁ a∈domm₂
@@ -188,13 +192,14 @@ disj-dom {m = m@(_ , uniq)} {m₁} {m₂} (m≡m₁∪m₂ , disj) a∈domm₁ a
     ∈mᵢ⇒∈m : ∀ {a} → a ∈ (m₁ ˢ) ⊎ a ∈ (m₂ ˢ) → a ∈ (m ˢ)
     ∈mᵢ⇒∈m = proj₂ m≡m₁∪m₂ ∘ to ∈-∪
 
-InjectiveOn : Set A → (A → B) → Type
+InjectiveOn : ⦃ _ : Cs A ⦄ → Set A → (A → B) → Type ℓ
 InjectiveOn X f = ∀ {x y} → x ∈ X → y ∈ X → f x ≡ f y → x ≡ y
 
-weaken-Injective : ∀ {X : Set A} {f : A → B} → Injective _≡_ _≡_ f → InjectiveOn X f
+weaken-Injective : ⦃ _ : Cs A ⦄ → ∀ {X : Set A} {f : A → B} → Injective _≡_ _≡_ f → InjectiveOn X f
 weaken-Injective p _ _ = p
 
-mapˡ-uniq : {f : A → A'}
+mapˡ-uniq : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs A' ⦄ → ⦃ _ : Cs B ⦄
+  → {R : Rel A B} {f : A → A'}
   → {@(tactic by-eq) inj : InjectiveOn (dom R) f}
   → left-unique R
   → left-unique (mapˡ f R)
@@ -206,35 +211,38 @@ mapˡ-uniq {inj = inj} uniq = λ h h' → case ∈⇔P h ,′ ∈⇔P h' of λ w
                                   (×-≡,≡←≡ eqb))
               Hb
 
-mapʳ-uniq : {f : B → B'} → left-unique R → left-unique (mapʳ f R)
+mapʳ-uniq : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → ⦃ _ : Cs B' ⦄
+  → {R : Rel A B} {f : B → B'} → left-unique R → left-unique (mapʳ f R)
 mapʳ-uniq uniq = λ h h' → case ∈⇔P h ,′ ∈⇔P h' of λ where
   ((_ , refl , Ha) , (_ , refl , Hb)) → cong _ $ uniq Ha Hb
 
-mapKeys : (f : A → A') → (m : Map A B)
+mapKeys : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs A' ⦄ → ⦃ _ : Cs B ⦄
+  → (f : A → A') → (m : Map A B)
   → {@(tactic by-eq) _ : InjectiveOn (dom (m ˢ)) f}
   → Map A' B
 mapKeys f (R , uniq) {inj} = mapˡ f R , mapˡ-uniq {inj = inj} uniq
 
-mapValues : (B → B') → Map A B → Map A B'
+mapValues : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → ⦃ _ : Cs B' ⦄
+  → (B → B') → Map A B → Map A B'
 mapValues f (R , uniq) = mapʳ f R , mapʳ-uniq uniq
 
-module Unionᵐ (sp-∈ : spec-∈ A) where
+module Unionᵐ ⦃ _ : Cs A ⦄ (sp-∈ : spec-∈ A) where
   infixr 6 _∪ˡ_
 
-  _∪ˡ'_ : Rel A B → Rel A B → Rel A B
+  _∪ˡ'_ : ⦃ _ : Cs B ⦄ → Rel A B → Rel A B → Rel A B
   m ∪ˡ' m' = m ∪ filter (sp-∘ (sp-¬ (sp-∈ {dom m})) proj₁) m'
 
   private
-     disjoint-proof : ∀ (m m' : Map A B)
+     disjoint-proof : ⦃ _ : Cs B ⦄ → ∀ (m m' : Map A B)
                     → disjoint (dom (m ˢ)) (dom (filterᵐ (sp-∘ (sp-¬ (sp-∈ {dom (m ˢ)})) (λ r → proj₁ r)) m' ˢ))
      disjoint-proof m m' p q with from ∈-map q
      ... | _ , refl , q with from ∈-filter q
      ... | q , _ = q p
 
-  _∪ˡ_ : Map A B → Map A B → Map A B
+  _∪ˡ_ : ⦃ _ : Cs B ⦄ → Map A B → Map A B → Map A B
   m ∪ˡ m' = disj-∪ m (filterᵐ (sp-∘ (sp-¬ sp-∈) proj₁) m') (disjoint-proof m m')
 
-  ∪ˡ-cong : ∀ {m m' m'' m''' : Map A B} → m ≡ᵐ m'' → m' ≡ᵐ m''' → (m ∪ˡ m') ≡ᵐ (m'' ∪ˡ m''')
+  ∪ˡ-cong : ⦃ _ : Cs B ⦄ → ∀ {m m' m'' m''' : Map A B} → m ≡ᵐ m'' → m' ≡ᵐ m''' → (m ∪ˡ m') ≡ᵐ (m'' ∪ˡ m''')
   ∪ˡ-cong {m = m} {m' = m'} {m'' = m''} {m''' = m'''} m≡m'' m'≡m'''
     = disj-∪-cong {m = m} {m' = (filterᵐ (sp-∘ (sp-¬ sp-∈) proj₁) m')} {m'' = m''} {m''' = (filterᵐ (sp-∘ (sp-¬ sp-∈) proj₁) m''')}
                   {m∩m'≡∅ = disjoint-proof m m'} {m''∩m'''≡∅ = disjoint-proof m'' m'''} m≡m'' (⊆ , ⊇)
@@ -247,12 +255,12 @@ module Unionᵐ (sp-∈ : spec-∈ A) where
       ⊆ p with from ∈-filter p
       ... | p , q = to ∈-filter ((λ x → p (dom-cong m≡m'' .proj₂ x)) , m'≡m''' .proj₁ q)
 
-  disjoint-∪ˡ-∪ : (H : disjoint (dom R) (dom R')) → R ∪ˡ' R' ≡ᵉ R ∪ R'
+  disjoint-∪ˡ-∪ : ⦃ _ : Cs B ⦄ → {R R' : Rel A B} → (H : disjoint (dom R) (dom R')) → R ∪ˡ' R' ≡ᵉ R ∪ R'
   disjoint-∪ˡ-∪ disj = from ≡ᵉ⇔≡ᵉ' λ _ → mk⇔
     (∈-∪⁺ ∘′ ⊎.map₂ (proj₂ ∘′ ∈⇔P) ∘′ ∈⇔P)
     (∈⇔P ∘′ ⊎.map₂ (to ∈-filter ∘′ (λ h → (flip disj (∈-map⁺'' h)) , h)) ∘ ∈⇔P)
 
-  singleton-∈-∪ˡ : a ∈ dom (m ˢ) → m ∪ˡ ❴ (a , b) ❵ᵐ ≡ᵐ m
+  singleton-∈-∪ˡ : ⦃ _ : Cs B ⦄ → {a : A} {b : B} {m : Map A B} → a ∈ dom (m ˢ) → m ∪ˡ ❴ (a , b) ❵ᵐ ≡ᵐ m
   singleton-∈-∪ˡ {m = m} a∈domm .proj₁ x with (from ∈-∪ x)
   ... | inj₁ h = h
   ... | inj₂ h = case from ∈-filter h of λ where
@@ -260,18 +268,22 @@ module Unionᵐ (sp-∈ : spec-∈ A) where
                                     (sym (from ∈-singleton h₂)) a∈domm
   singleton-∈-∪ˡ _ .proj₂ = ∪-⊆ˡ
 
-  insert : Map A B → A → B → Map A B
+  insert : ⦃ _ : Cs B ⦄ → Map A B → A → B → Map A B
   insert m a b = ❴ a , b ❵ᵐ ∪ˡ m
 
-  insertIfJust : ⦃ DecEq A ⦄ → A → Maybe B → Map A B → Map A B
+  insertIfJust : ⦃ _ : Cs B ⦄ → ⦃ DecEq A ⦄ → A → Maybe B → Map A B → Map A B
   insertIfJust x nothing  m  = m
   insertIfJust x (just y) m  = insert m x y
 
-  disjoint-∪ˡ-mapValues : {M M' : Map A B}
+-- disjoint-∪ˡ-mapValues needs both B and C constraints. It is defined as a
+-- standalone function so that both ∪ˡ on Map A B and ∪ˡ on Map A C can be used.
+module _ ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄ ⦃ _ : Cs C ⦄ where
+  disjoint-∪ˡ-mapValues : (sp-∈ : spec-∈ A) → {M M' : Map A B}
                           (f : B → C)
                           → (H : disjoint (dom (M ˢ)) (dom (M' ˢ)))
-                          → (mapValues f (M ∪ˡ M')) ˢ ≡ᵉ (mapValues f M ∪ˡ mapValues f M') ˢ
-  disjoint-∪ˡ-mapValues {M = M} {M'} f disj = begin
+                          → let open Unionᵐ sp-∈ in
+                            (mapValues f (M ∪ˡ M')) ˢ ≡ᵉ (mapValues f M ∪ˡ mapValues f M') ˢ
+  disjoint-∪ˡ-mapValues sp-∈ {M = M} {M'} f disj = begin
     proj₁ (mapValues f (M ∪ˡ M'))
     ≈⟨ map-≡ᵉ (disjoint-∪ˡ-∪ disj) ⟩
     (mapʳ f ((proj₁ M) ∪ (proj₁ M')))
@@ -281,23 +293,26 @@ module Unionᵐ (sp-∈ : spec-∈ A) where
     proj₁ (mapValues f M ∪ˡ mapValues f M')
     ∎
    where open SetoidReasoning ≡ᵉ-Setoid
+         open Unionᵐ sp-∈
 
-map⦅×-dup⦆-uniq : ∀ {x : Set A} → left-unique (mapˢ ×-dup x)
+map⦅×-dup⦆-uniq : ⦃ _ : Cs A ⦄ → ∀ {x : Set A} → left-unique (mapˢ ×-dup x)
 map⦅×-dup⦆-uniq x y with ∈-map⁻' x | ∈-map⁻' y
 ... | fst , refl , _ | .fst , refl , _ = refl
 
-mapˡ∘map⦅×-dup⦆-uniq : ∀ {S : Set A} {f : A → B}
+mapˡ∘map⦅×-dup⦆-uniq : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄
+  → ∀ {S : Set A} {f : A → B}
   → {@(tactic by-eq) inj : Injective _≡_ _≡_ f}
   → left-unique $ mapˡ f (mapˢ ×-dup S)
 mapˡ∘map⦅×-dup⦆-uniq {inj = inj} = mapˡ-uniq {inj = λ _ _ → inj} map⦅×-dup⦆-uniq
 
-idMap : Set A → Map A A
+idMap : ⦃ _ : Cs A ⦄ → Set A → Map A A
 idMap s = -, map⦅×-dup⦆-uniq {x = s}
 
-mapFromFun : (A → B) → Set A → Map A B
+mapFromFun : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → (A → B) → Set A → Map A B
 mapFromFun f s = mapValues f (idMap s)
 
-mapFromFun-cong : ∀ {X Y : Set A} (f : A → B)
+mapFromFun-cong : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄
+  → ∀ {X Y : Set A} (f : A → B)
                 → X ≡ᵉ Y
                 → mapFromFun f X ≡ᵐ mapFromFun f Y
 mapFromFun-cong {X = X} {Y} f X≡Y = mapFromFunfX⊆mapFromFunfY , mapFromFunfY⊆mapFromFunfX
@@ -312,36 +327,44 @@ mapFromFun-cong {X = X} {Y} f X≡Y = mapFromFunfX⊆mapFromFunfY , mapFromFunfY
       ... | ((a , b) , refl , p) with from ∈-map p
       ... | (c , refl , p) = to ∈-map ((a , b) , refl , (to ∈-map (a , (refl , (X≡Y .proj₂ p)))))
 
-mapWithKey-uniq : {f : A → B → B'}
+mapWithKey-uniq : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → ⦃ _ : Cs B' ⦄
+  → {R : Rel A B} {f : A → B → B'}
   → left-unique R
   → left-unique (mapˢ (λ { (x , y) → x , f x y }) R)
 mapWithKey-uniq {f = f} uniq p q with from ∈-map p | from ∈-map q
 ... | (x , y) , refl , xy∈r | (x' , y') , refl , xy'∈r = cong (f x) (uniq xy∈r xy'∈r)
 
-mapWithKey : (A → B → B') → Map A B → Map A B'
+mapWithKey : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → ⦃ _ : Cs B' ⦄
+  → (A → B → B') → Map A B → Map A B'
 mapWithKey f m@(r , p) = mapˢ (λ { (x , y) → x , f x y}) r , mapWithKey-uniq p
 
-mapValues-dom : {f : B → C} → dom (m ˢ) ≡ᵉ dom (mapValues f m ˢ)
+mapValues-dom : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → ⦃ _ : Cs C ⦄
+  → {m : Map A B} {f : B → C} → dom (m ˢ) ≡ᵉ dom (mapValues f m ˢ)
 mapValues-dom {m = _ , _} = mapʳ-dom
 
-_∣'_ : {P : A → Type} → Map A B → specProperty P → Map A B
+_∣'_ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄
+  → {P : A → Type} → Map A B → specProperty P → Map A B
 m ∣' P? = filterᵐ (sp-∘ P? proj₁) m
 
-_∣^'_ : {P : B → Type} → Map A B → specProperty P → Map A B
+_∣^'_ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄
+  → {P : B → Type} → Map A B → specProperty P → Map A B
 m ∣^' P? = filterᵐ (sp-∘ P? proj₂) m
 
-constMap : Set A → B → Map A B
+constMap : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → Set A → B → Map A B
 constMap X b = mapˢ (_, b) X , λ x x₁ →
   trans (proj₂ $ ×-≡,≡←≡ $ proj₁ $ proj₂ (∈⇔P x))
         (sym $ proj₂ $ ×-≡,≡←≡ $ proj₁ $ proj₂ (∈⇔P x₁))
 
-constMap-dom : dom (constMap X b ˢ) ≡ᵉ X
+constMap-dom : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄
+  → {X : Set A} {b : B} → dom (constMap X b ˢ) ≡ᵉ X
 constMap-dom .proj₁ a∈dom with from dom∈ a∈dom
 ... | b' , ab'∈map with from ∈-map ab'∈map
 ... | a' , ab'≡a'b , a'∈X = subst (_∈ _) (sym (proj₁ (×-≡,≡←≡ ab'≡a'b))) a'∈X
 constMap-dom .proj₂ a∈X = to dom∈ (_ , to ∈-map (_ , refl , a∈X))
 
-mapPartialLiftKey-just-uniq : ∀ {f : A → B → Maybe B'}
+mapPartialLiftKey-just-uniq : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → ⦃ _ : Cs B' ⦄
+
+  → {R : Rel A B} {a : A} {b b' : B'} → ∀ {f : A → B → Maybe B'}
   → left-unique R
   → just (a , b)  ∈ mapˢ (mapPartialLiftKey f) R
   → just (a , b') ∈ mapˢ (mapPartialLiftKey f) R
@@ -352,7 +375,9 @@ mapPartialLiftKey-just-uniq {f = f} prop a∈ a'∈ =
   in
     just-injective $ trans eq (trans (cong (f _) (prop ax∈r ax'∈r)) (sym eq'))
 
-mapPartial-uniq : ∀ {r : Rel A B} {f : A → B → Maybe B' }
+mapPartial-uniq : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → ⦃ _ : Cs B' ⦄
+
+  → ∀ {r : Rel A B} {f : A → B → Maybe B' }
   → left-unique r
   → left-unique (mapPartial (mapPartialLiftKey f) r)
 mapPartial-uniq {f = f} prop {a} {b} {b'} p q =
@@ -360,15 +385,18 @@ mapPartial-uniq {f = f} prop {a} {b} {b'} p q =
       q = ∈-map′ q
   in mapPartialLiftKey-just-uniq {f = f} prop (⊆-mapPartial p) (⊆-mapPartial q)
 
-mapMaybeWithKeyᵐ : (A → B → Maybe B') → Map A B → Map A B'
+mapMaybeWithKeyᵐ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → ⦃ _ : Cs B' ⦄
+
+  → (A → B → Maybe B') → Map A B → Map A B'
 mapMaybeWithKeyᵐ f (rel , prop) = mapMaybeWithKey f rel , mapPartial-uniq {f = f} prop
 
-mapFromPartialFun : (A → Maybe B) → Set A → Map A B
+mapFromPartialFun : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄
+  → (A → Maybe B) → Set A → Map A B
 mapFromPartialFun f s = mapMaybeWithKeyᵐ (λ _ → f) (idMap s)
 
-module Restrictionᵐ (sp-∈ : spec-∈ A) where
-  private module R = Restriction sp-∈
-  open Unionᵐ sp-∈
+module Restrictionᵐ ⦃ cA : Cs A ⦄ ⦃ cB : Cs B ⦄ (sp-∈ : spec-∈ A) where
+  private module R = Restriction ⦃ cA ⦄ ⦃ cB ⦄ sp-∈
+  open Unionᵐ ⦃ cA ⦄ sp-∈
 
   _∣_ : Map A B → Set A → Map A B
   m ∣ X = ⊆-map (R._∣ X) R.res-⊆ m
@@ -387,10 +415,10 @@ module Restrictionᵐ (sp-∈ : spec-∈ A) where
   mapSingleValue : (B → B) → Map A B → A → Map A B
   mapSingleValue f m a = mapValueRestricted f m ❴ a ❵
 
-  curryᵐ : Map (A × B) C → A → Map B C
+  curryᵐ : ⦃ _ : Cs C ⦄ → Map (A × B) C → A → Map B C
   curryᵐ m a = R.curryʳ (m ˢ) a , λ h h' → proj₂ m (R.∈-curryʳ h) (R.∈-curryʳ h')
 
-  res-dom∈ : ∀ {b} → (a , b) ∈ (m ∣ X) ˢ ⇔ ((a , b) ∈ m ˢ × a ∈ X)
+  res-dom∈ : {a : A} {b : B} {m : Map A B} {X : Set A} → (a , b) ∈ (m ∣ X) ˢ ⇔ ((a , b) ∈ m ˢ × a ∈ X)
   res-dom∈ = R.∈-res
 
   res-cong : ∀ {m m' : Map A B} {X Y : Set A}
@@ -406,12 +434,12 @@ module Restrictionᵐ (sp-∈ : spec-∈ A) where
       ⊆ p with to (res-dom∈ {m = m}) p
       ... | (p , q) = from (res-dom∈ {m = m'}) (m≡m' .proj₁ p , (X≡Y .proj₁ q))
 
-  res-subset : R ⊆ m ˢ → (m ∣ dom R) ˢ ≡ᵉ R
+  res-subset : {R : Rel A B} {m : Map A B} → R ⊆ m ˢ → (m ∣ dom R) ˢ ≡ᵉ R
   res-subset {m = _ , uniq} R⊆m .proj₁ {a , b} ab∈ with from dom∈ (R.res-dom $ to dom∈ (b , ab∈))
   ... | b' , ab'∈ = subst (λ u → (a , u) ∈ _) (uniq (R⊆m ab'∈) $ R.res-⊆ ab∈) ab'∈
   res-subset {m = m} R⊆m .proj₂ ab∈ = from (res-dom∈ {m = m}) (R⊆m ab∈ , to dom∈ (_ , ab∈))
 
-  res-singleton : ∀ {k} → k ∈ dom (m ˢ) → ∃[ v ] m ∣ ❴ k ❵ ≡ᵐ ❴ k , v ❵ᵐ
+  res-singleton : {m : Map A B} → ∀ {k} → k ∈ dom (m ˢ) → ∃[ v ] m ∣ ❴ k ❵ ≡ᵐ ❴ k , v ❵ᵐ
   res-singleton {m = m@(_ , uniq)} k∈domm
     with (k , v) , (refl , h) ← ∈⇔P k∈domm
     = v
@@ -422,21 +450,21 @@ module Restrictionᵐ (sp-∈ : spec-∈ A) where
                         (sym $ from ∈-singleton a∈❴k,v❵)
                         (∈⇔P (to ∈-singleton refl , h))
 
-  res-singleton' : ∀ {k v} → (k , v) ∈ m ˢ → m ∣ ❴ k ❵ ≡ᵐ ❴ k , v ❵ᵐ
+  res-singleton' : {m : Map A B} → ∀ {k v} → (k , v) ∈ m ˢ → m ∣ ❴ k ❵ ≡ᵐ ❴ k , v ❵ᵐ
   res-singleton' {m = m} kv∈m
     with _ , h ← res-singleton {m = m} (∈⇔P (-, (refl , kv∈m)))
     = subst _ (sym $ proj₂ m kv∈m (R.res-⊆ $ proj₂ h $ to ∈-singleton refl)) h
 
-  res-singleton⁺ : {k : A}{v : B} → (k , v) ∈ m ˢ → (k , v) ∈ (m ∣ ❴ k ❵)ˢ
+  res-singleton⁺ : {m : Map A B} → {k : A}{v : B} → (k , v) ∈ m ˢ → (k , v) ∈ (m ∣ ❴ k ❵)ˢ
   res-singleton⁺ kv∈m = to ∈-filter ((to ∈-singleton refl) , kv∈m)
 
-  res-singleton-inhabited : ∀ {k a} → a ∈ (m ∣ ❴ k ❵) ˢ → k ∈ dom (m ˢ)
+  res-singleton-inhabited : {m : Map A B} → ∀ {k a} → a ∈ (m ∣ ❴ k ❵) ˢ → k ∈ dom (m ˢ)
   res-singleton-inhabited {m = m} {k} {a} a∈ =
     to dom∈ ( proj₂ a , subst (λ x → (x , proj₂ a) ∈ (m ˢ))
                                 (from ∈-singleton (R.res-dom (∈-dom a∈)))
                                 (R.res-⊆ a∈) )
 
-  res-singleton'' : ∀ {k a} → a ∈ (m ∣ ❴ k ❵)ˢ → ∃[ v ] a ≡ (k , v)
+  res-singleton'' : {m : Map A B} → ∀ {k a} → a ∈ (m ∣ ❴ k ❵)ˢ → ∃[ v ] a ≡ (k , v)
   res-singleton'' {m = m}{k}{a} a∈m =
     let (v , m|≡) = res-singleton {m = m} (res-singleton-inhabited{m = m} a∈m) in
     v , from ∈-singleton (proj₁ m|≡ a∈m)
@@ -449,11 +477,11 @@ module Restrictionᵐ (sp-∈ : spec-∈ A) where
   update x (just y) m = insert m x y
   update x nothing  m = m ∣ ❴ x ❵ ᶜ
 
-module Lookupᵐ (sp-∈ : spec-∈ A) where
+module Lookupᵐ ⦃ cA : Cs A ⦄ ⦃ cB : Cs B ⦄ (sp-∈ : spec-∈ A) where
   open import Relation.Nullary.Decidable
-  private module R = Restriction sp-∈
-  open Unionᵐ sp-∈
-  open Restriction sp-∈
+  private module R = Restriction ⦃ cA ⦄ ⦃ cB ⦄ sp-∈
+  open Unionᵐ ⦃ cA ⦄ sp-∈
+  open Restriction ⦃ cA ⦄ ⦃ cB ⦄ sp-∈
 
   module _ (m@(mˢ , uniq) : Map A B) (x : A) where
     lookupᵐ : {@(tactic initTac assumption') _ : x ∈ dom (m ˢ)} → B
@@ -473,11 +501,12 @@ module Lookupᵐ (sp-∈ : spec-∈ A) where
     ∈⇒lookup≡just P ⦃ ⁇ (yes q') ⦄ = cong just (∈-lookup q' P)
     ∈⇒lookup≡just P ⦃ ⁇ (no ¬q') ⦄ = ⊥-elim (¬q' (to dom∈ (_ , P)))
 
-  pullbackMap : (m : Map A B) → ⦃ ∀ {x} → (x ∈ dom (m ˢ)) ⁇ ⦄ → (A' → A) → Set A' → Map A' B
+  pullbackMap : ⦃ _ : Cs A' ⦄
+    → (m : Map A B) → ⦃ ∀ {x} → (x ∈ dom (m ˢ)) ⁇ ⦄ → (A' → A) → Set A' → Map A' B
   pullbackMap m f s = mapMaybeWithKeyᵐ (λ a _ → lookupᵐ? m (f a)) (idMap s)
 
-module Corestrictionᵐ (sp-∈ : spec-∈ B) where
-  private module R = Corestriction sp-∈
+module Corestrictionᵐ ⦃ cA : Cs A ⦄ ⦃ cB : Cs B ⦄ (sp-∈ : spec-∈ B) where
+  private module R = Corestriction ⦃ cA ⦄ ⦃ cB ⦄ sp-∈
 
   _∣^_ : Map A B → Set B → Map A B
   m ∣^ X = ⊆-map (R._∣^ X) R.cores-⊆ m

--- a/src/Axiom/Set/Map/Dec.agda
+++ b/src/Axiom/Set/Map/Dec.agda
@@ -1,7 +1,7 @@
 {-# OPTIONS --safe --no-import-sorts #-}
 open import Axiom.Set using (Theoryᵈ; Theory)
 
-module Axiom.Set.Map.Dec (thᵈ : Theoryᵈ) where
+module Axiom.Set.Map.Dec {ℓ_c} (thᵈ : Theoryᵈ {ℓ_c}) where
 
 open import abstract-set-theory.Prelude hiding (map; Monoid)
 
@@ -19,11 +19,13 @@ open Equivalence
 
 private variable A B C D : Type
 
-module Lookupᵐᵈ (sp-∈ : spec-∈ A) where
-  open Lookupᵐ sp-∈
+module Lookupᵐᵈ ⦃ _ : Cs A ⦄ (sp-∈ : spec-∈ A) where
+  private module L {B} ⦃ _ : Cs B ⦄ = Lookupᵐ {B = B} sp-∈
+  open L public
   open Unionᵐ sp-∈
 
-  unionThese : ⦃ DecEq A ⦄ → (m : Map A B) (m' : Map A C) (x : A)
+  unionThese : ⦃ _ : Cs B ⦄ → ⦃ _ : Cs C ⦄
+    → ⦃ DecEq A ⦄ → (m : Map A B) (m' : Map A C) (x : A)
     → x ∈ dom (m ˢ) ∪ dom (m' ˢ) → These B C
   unionThese m m' x dp with x ∈? dom (m ˢ) | x ∈? dom (m' ˢ)
   ... | yes mr | yes mr' = these (lookupᵐ m x) (lookupᵐ m' x)
@@ -32,7 +34,9 @@ module Lookupᵐᵈ (sp-∈ : spec-∈ A) where
   ... | no  mr | no  mr' = Sum.[ flip contradiction mr , flip contradiction mr' ]
                                (from ∈-∪ dp)
 
-  unionWith : ⦃ DecEq A ⦄ → (These B C → D) → Map A B → Map A C → Map A D
+  unionWith : ⦃ _ : Cs B ⦄ → ⦃ _ : Cs C ⦄ → ⦃ _ : Cs D ⦄
+    → ⦃ DecEq A ⦄ → ⦃ ∀ {X : Set A} → Cs (∃[ a ] a ∈ X) ⦄
+    → (These B C → D) → Map A B → Map A C → Map A D
   unionWith f m@(r , p) m'@(r' , p') = m'' , helper
      where
        d = dom r ∪ dom r'
@@ -50,13 +54,15 @@ module Lookupᵐᵈ (sp-∈ : spec-∈ A) where
          with refl ← trans (sym eq) eq' = refl
 
   intersectionWith
-    : (B → C → D)
+    : ⦃ _ : Cs B ⦄ → ⦃ _ : Cs C ⦄ → ⦃ _ : Cs D ⦄
+    → (B → C → D)
     → (m : Map A B) ⦃ _ : ∀ {x} → (x ∈ dom (m ˢ)) ⁇ ⦄
     → Map A C
     → Map A D
   intersectionWith f m = mapMaybeWithKeyᵐ (λ a c → flip f c <$> lookupᵐ? m a)
 
-  module _ {V : Type} ⦃ mon : CommutativeMonoid 0ℓ 0ℓ V ⦄ ⦃ _ : DecEq A ⦄ where
+  module _ {V : Type} ⦃ _ : Cs V ⦄ ⦃ mon : CommutativeMonoid 0ℓ 0ℓ V ⦄
+           ⦃ _ : DecEq A ⦄ ⦃ _ : ∀ {X : Set A} → Cs (∃[ a ] a ∈ X) ⦄ where
     infixr 6 _∪⁺_
     open CommutativeMonoid mon
 
@@ -75,8 +81,8 @@ module Lookupᵐᵈ (sp-∈ : spec-∈ A) where
                                   (sym $ proj₁ (×-≡,≡←≡ $ proj₁ (proj₂ ∈-dom∪⁺)))
                                   (proj₂ $ proj₁ ∈-dom∪⁺)
         where
-        ∈-dom∪⁺ : ∃[ c ] (a , proj₁ (from dom∈ a∈)) ≡ ∪dom-lookup c
-                          × c ∈ incl-set (dom (m ˢ) ∪ dom (m' ˢ))
+        ∈-dom∪⁺ : ∃[ c ] ((a , proj₁ (from dom∈ a∈)) ≡ ∪dom-lookup c
+                          × c ∈ incl-set (dom (m ˢ) ∪ dom (m' ˢ)))
         ∈-dom∪⁺ = from ∈-map $ proj₂ $ from dom∈ a∈
 
       ∪dom⊆dom∪⁺ : dom (m ˢ) ∪ dom (m' ˢ) ⊆ dom ((m ∪⁺ m') ˢ)
@@ -166,7 +172,8 @@ module Lookupᵐᵈ (sp-∈ : spec-∈ A) where
 
   opaque
     filterᵐ-singleton-false
-      : {P : A → Type} {k : A} {v : B} (spP : specProperty P)
+      : ⦃ _ : Cs B ⦄
+      → {P : A → Type} {k : A} {v : B} (spP : specProperty P)
       → ¬ P k → filterᵐ (sp-∘ spP proj₁) ❴ k , v ❵ᵐ ≡ᵐ ∅ᵐ
     filterᵐ-singleton-false {P = P} _ ¬p .proj₁ x =
       ⊥-elim $ ¬p $
@@ -179,7 +186,8 @@ module Lookupᵐᵈ (sp-∈ : spec-∈ A) where
         open import Axiom.Set.Properties th using (∉-∅)
 
     add-excluded-∪ˡ-l
-      : {P : A → Type} {k : A} {v : B}
+      : ⦃ _ : Cs B ⦄
+      → {P : A → Type} {k : A} {v : B}
         ⦃ _ : DecEq A ⦄
         (spP : specProperty P) (m : Map A B)
       → ¬ P k

--- a/src/Axiom/Set/Predicates.agda
+++ b/src/Axiom/Set/Predicates.agda
@@ -11,9 +11,11 @@ import Function.Properties.Equivalence as E
 
 Pred-Model : Theory
 Pred-Model = λ where
+  .sc            → ⊤-SetConstraint
   .Set           → λ A → A → Type
   ._∈_           → λ x X → X x
   .sp            → ⊤-SpecProperty
+  .c-Set         → mkCstr tt
   .specification {_} {P} → λ X _ → P P.∩ X , E.refl
   .unions        → λ X → (λ a → ∃[ Z ] X Z × Z a) , E.refl
   .replacement   → λ f X → (λ b → ∃[ a ] b ≡ f a × X a) , E.refl

--- a/src/Axiom/Set/Properties.agda
+++ b/src/Axiom/Set/Properties.agda
@@ -2,7 +2,7 @@
 
 open import Axiom.Set using (Theory)
 
-module Axiom.Set.Properties {ℓ} (th : Theory {ℓ}) where
+module Axiom.Set.Properties {ℓ} {ℓ_c} (th : Theory {ℓ} {ℓ_c}) where
 
 open import abstract-set-theory.Prelude hiding (isEquivalence; trans; map; map₂)
 open Theory th
@@ -34,33 +34,32 @@ open Equivalence
 
 private variable
   A B C : Type ℓ
-  X Y Z : Set A
 
-module _ {f : A → B} {X} {b} where
+module _ ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄ {f : A → B} {X} {b} where
   ∈-map⁻' : b ∈ map f X → (∃[ a ] b ≡ f a × a ∈ X)
   ∈-map⁻' = from ∈-map
 
   ∈-map⁺' : (∃[ a ] b ≡ f a × a ∈ X) → b ∈ map f X
   ∈-map⁺' = to ∈-map
 
-∈-map⁺'' : ∀ {f : A → B} {X} {a} → a ∈ X → f a ∈ map f X
+∈-map⁺'' : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → ∀ {f : A → B} {X} {a} → a ∈ X → f a ∈ map f X
 ∈-map⁺'' h = to ∈-map (-, refl , h)
 
-module _ {X : Set A} {P : A → Type} {sp-P : specProperty P} {a} where
+module _ ⦃ _ : Cs A ⦄ {X : Set A} {P : A → Type} {sp-P : specProperty P} {a} where
   ∈-filter⁻' : a ∈ filter sp-P X → (P a × a ∈ X)
   ∈-filter⁻' = from ∈-filter
 
   ∈-filter⁺' : (P a × a ∈ X) → a ∈ filter sp-P X
   ∈-filter⁺' = to ∈-filter
 
-module _ {X Y : Set A} {a} where
+module _ ⦃ _ : Cs A ⦄ {X Y : Set A} {a} where
   ∈-∪⁻ : a ∈ X ∪ Y → a ∈ X ⊎ a ∈ Y
   ∈-∪⁻ = from ∈-∪
 
   ∈-∪⁺ : a ∈ X ⊎ a ∈ Y → a ∈ X ∪ Y
   ∈-∪⁺ = to ∈-∪
 
-module _ {l : List A} {a} where
+module _ ⦃ _ : Cs A ⦄ {l : List A} {a} where
   ∈-fromList⁻ : a ∈ fromList l → a ∈ˡ l
   ∈-fromList⁻ = from ∈-fromList
 
@@ -81,28 +80,28 @@ private macro
     ( quote ∈-filter⁻' ∷ quote ∈-∪⁻ ∷ quote ∈-map⁻' ∷ quote ∈-fromList⁻
     ∷ quote ∈-filter⁺' ∷ quote ∈-∪⁺ ∷ quote ∈-map⁺' ∷ quote ∈-fromList⁺ ∷ [])
 
-_≡_⨿_ : Set A → Set A → Set A → Type ℓ
+_≡_⨿_ : ⦃ _ : Cs A ⦄ → Set A → Set A → Set A → Type ℓ
 X ≡ Y ⨿ Z = X ≡ᵉ Y ∪ Z × disjoint Y Z
 
 -- FIXME: proving this has some weird issues when making a implicit in
 -- in the definiton of _≡ᵉ'_
-≡ᵉ⇔≡ᵉ' : X ≡ᵉ Y ⇔ X ≡ᵉ' Y
+≡ᵉ⇔≡ᵉ' : ⦃ _ : Cs A ⦄ → {X Y : Set A} → X ≡ᵉ Y ⇔ X ≡ᵉ' Y
 ≡ᵉ⇔≡ᵉ' = mk⇔
   (λ where (X⊆Y , Y⊆X) _ → mk⇔ X⊆Y Y⊆X)
   (λ a∈X⇔a∈Y → (λ {_} → to (a∈X⇔a∈Y _)) , λ {_} → from (a∈X⇔a∈Y _))
 
-cong-⊆⇒cong : {f : Set A → Set B} → f Preserves _⊆_ ⟶ _⊆_ → f Preserves _≡ᵉ_ ⟶ _≡ᵉ_
+cong-⊆⇒cong : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → {f : Set A → Set B} → f Preserves _⊆_ ⟶ _⊆_ → f Preserves _≡ᵉ_ ⟶ _≡ᵉ_
 cong-⊆⇒cong h X≡ᵉX' = h (proj₁ X≡ᵉX') , h (proj₂ X≡ᵉX')
 
-cong-⊆⇒cong₂ : {f : Set A → Set B → Set C}
+cong-⊆⇒cong₂ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → ⦃ _ : Cs C ⦄ → {f : Set A → Set B → Set C}
              → f Preserves₂ _⊆_ ⟶ _⊆_ ⟶ _⊆_ → f Preserves₂ _≡ᵉ_ ⟶ _≡ᵉ_ ⟶ _≡ᵉ_
 cong-⊆⇒cong₂ h X≡ᵉX' Y≡ᵉY' = h (proj₁ X≡ᵉX') (proj₁ Y≡ᵉY')
                            , h (proj₂ X≡ᵉX') (proj₂ Y≡ᵉY')
 
-⊆-Transitive : Transitive (_⊆_ {A})
+⊆-Transitive : ⦃ _ : Cs A ⦄ → Transitive (_⊆_ {A})
 ⊆-Transitive X⊆Y Y⊆Z = Y⊆Z ∘ X⊆Y
 
-≡ᵉ-isEquivalence : IsEquivalence (_≡ᵉ_ {A})
+≡ᵉ-isEquivalence : ⦃ _ : Cs A ⦄ → IsEquivalence (_≡ᵉ_ {A})
 ≡ᵉ-isEquivalence = record
   { refl  = id , id
   ; sym   = λ where (h , h') → (h' , h)
@@ -110,33 +109,35 @@ cong-⊆⇒cong₂ h X≡ᵉX' Y≡ᵉY' = h (proj₁ X≡ᵉX') (proj₁ Y≡�
                       , ⊆-Transitive (proj₂ eq₂) (proj₂ eq₁)
   }
 
-≡ᵉ-Setoid : ∀ {A} → Setoid ℓ ℓ
+≡ᵉ-Setoid : ∀ {A} → ⦃ _ : Cs A ⦄ → Setoid ℓ ℓ
 ≡ᵉ-Setoid {A} = record
   { Carrier       = Set A
   ; _≈_           = _≡ᵉ_
   ; isEquivalence = ≡ᵉ-isEquivalence
   }
 
-⊆-isPreorder : IsPreorder (_≡ᵉ_ {A}) _⊆_
+⊆-isPreorder : ⦃ _ : Cs A ⦄ → IsPreorder (_≡ᵉ_ {A}) _⊆_
 ⊆-isPreorder = λ where
   .isEquivalence → ≡ᵉ-isEquivalence
   .reflexive     → proj₁
   .trans         → ⊆-Transitive
     where open IsPreorder
 
-⊆-Preorder : {A} → Preorder _ _ _
+⊆-Preorder : ∀ {A} → ⦃ _ : Cs A ⦄ → Preorder _ _ _
 ⊆-Preorder {A} = record
   { Carrier = Set A ; _≈_ = _≡ᵉ_ ; _≲_ = _⊆_ ; isPreorder = ⊆-isPreorder }
 
-⊆-PartialOrder : IsPartialOrder (_≡ᵉ_ {A}) _⊆_
+⊆-PartialOrder : ⦃ _ : Cs A ⦄ → IsPartialOrder (_≡ᵉ_ {A}) _⊆_
 ⊆-PartialOrder = record
   { isPreorder = ⊆-isPreorder
   ; antisym    = _,_ }
 
-∈-× : {a : A} {b : B} → (a , b) ∈ X → (a ∈ map proj₁ X × b ∈ map proj₂ X)
+∈-× : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄
+  → {a : A} {b : B} {X : Set (A × B)} → (a , b) ∈ X → (a ∈ map proj₁ X × b ∈ map proj₂ X)
 ∈-× {a = a} {b} x = to ∈-map ((a , b) , refl , x) , to ∈-map ((a , b) , refl , x)
 
-module _ {f : A → B} {g : B → C} where
+module _ ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄ ⦃ _ : Cs C ⦄
+         {f : A → B} {g : B → C} {X : Set A} where
   map-⊆∘ : map g (map f X) ⊆ map (g ∘ f) X
   map-⊆∘ a∘∈
     with b , a≡gb , b∈prfX ← from ∈-map a∘∈
@@ -153,32 +154,32 @@ module _ {f : A → B} {g : B → C} where
   ∈-map⁺-∘ : ∀ {b} → b ∈ map f X → g b ∈ map (g ∘ f) X
   ∈-map⁺-∘ = map-⊆∘ ∘ ∈-map⁺''
 
-map-⊆ : {X Y : Set A} {f : A → B} → X ⊆ Y → map f X ⊆ map f Y
+map-⊆ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → {X Y : Set A} {f : A → B} → X ⊆ Y → map f X ⊆ map f Y
 map-⊆ x⊆y a∈map with from ∈-map a∈map
 ... | a₁ , a≡fa₁ , a₁∈x = to ∈-map (a₁ , a≡fa₁ , x⊆y a₁∈x)
 
-map-≡ᵉ : {X Y : Set A} {f : A → B} → X ≡ᵉ Y → map f X ≡ᵉ map f Y
+map-≡ᵉ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → {X Y : Set A} {f : A → B} → X ≡ᵉ Y → map f X ≡ᵉ map f Y
 map-≡ᵉ (x⊆y , y⊆x) = map-⊆ x⊆y , map-⊆ y⊆x
 
-∉-∅ : {a : A} → a ∉ ∅
+∉-∅ : ⦃ _ : Cs A ⦄ → {a : A} → a ∉ ∅
 ∉-∅ h = case ∈⇔P h of λ ()
 
-∅-minimum : Minimum (_⊆_ {A}) ∅
+∅-minimum : ⦃ _ : Cs A ⦄ → Minimum (_⊆_ {A}) ∅
 ∅-minimum = λ _ → ⊥-elim ∘ ∉-∅
 
-∅-least : X ⊆ ∅ → X ≡ᵉ ∅
+∅-least : ⦃ _ : Cs A ⦄ → {X : Set A} → X ⊆ ∅ → X ≡ᵉ ∅
 ∅-least X⊆∅ = (X⊆∅ , ∅-minimum _)
 
-∅-weakly-finite : weakly-finite {A = A} ∅
+∅-weakly-finite : ⦃ _ : Cs A ⦄ → weakly-finite {A = A} ∅
 ∅-weakly-finite = [] , ⊥-elim ∘ ∉-∅
 
-∅-finite : finite {A = A} ∅
+∅-finite : ⦃ _ : Cs A ⦄ → finite {A = A} ∅
 ∅-finite = [] , mk⇔ (⊥-elim ∘ ∉-∅) λ ()
 
-map-∅ : {X : Set A} {f : A → B} → map f ∅ ≡ᵉ ∅
+map-∅ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → {f : A → B} → map f ∅ ≡ᵉ ∅
 map-∅ = ∅-least λ x∈map → case ∈-map⁻' x∈map of λ where (_ , _ , h) → ⊥-elim (∉-∅ h)
 
-map-∪ : {X Y : Set A} → (f : A → B) → map f (X ∪ Y) ≡ᵉ map f X ∪ map f Y
+map-∪ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → {X Y : Set A} → (f : A → B) → map f (X ∪ Y) ≡ᵉ map f X ∪ map f Y
 map-∪ {X = X} {Y} f = from ≡ᵉ⇔≡ᵉ' λ b →
     b ∈ map f (X ∪ Y)
       ∼⟨ R.SK-sym ∈-map ⟩
@@ -195,17 +196,17 @@ map-∪ {X = X} {Y} f = from ≡ᵉ⇔≡ᵉ' λ b →
     b ∈ map f X ∪ map f Y ∎
   where open R.EquationalReasoning
 
-mapPartial-∅ : {f : A → Maybe B} → mapPartial f ∅ ≡ᵉ ∅
+mapPartial-∅ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → {f : A → Maybe B} → mapPartial f ∅ ≡ᵉ ∅
 mapPartial-∅ {f = f} = ∅-least λ x∈map → case from (∈-mapPartial {f = f}) x∈map of λ where
   (_ , h , _) → ⊥-elim (∉-∅ h)
 
-singleton-strongly-finite : {a : A} → strongly-finite (singleton a)
+singleton-strongly-finite : ⦃ _ : Cs A ⦄ → {a : A} → strongly-finite (singleton a)
 singleton-strongly-finite = _ , All.[] AllPairs.∷ AllPairs.[] , R.SK-sym ∈-fromList
 
-card-singleton : {a : A} → card (singleton a , singleton-strongly-finite) ≡ 1
+card-singleton : ⦃ _ : Cs A ⦄ → {a : A} → card (singleton a , singleton-strongly-finite) ≡ 1
 card-singleton = refl
 
-card-≡ᵉ : (X Y : Σ (Set A) strongly-finite) → proj₁ X ≡ᵉ proj₁ Y → card X ≡ card Y
+card-≡ᵉ : ⦃ _ : Cs A ⦄ → (X Y : Σ (Set A) strongly-finite) → proj₁ X ≡ᵉ proj₁ Y → card X ≡ card Y
 card-≡ᵉ (X , lX , lXᵘ , eqX) (Y , lY , lYᵘ , eqY) X≡Y =
   ↭-length $ ∼bag⇒↭ $ unique∧set⇒bag lXᵘ lYᵘ λ {a} →
     a ∈ˡ lX  ∼⟨ R.SK-sym eqX ⟩
@@ -214,7 +215,7 @@ card-≡ᵉ (X , lX , lXᵘ , eqX) (Y , lY , lYᵘ , eqY) X≡Y =
     a ∈ˡ lY  ∎
   where open R.EquationalReasoning
 
-singleton-≢-∅ : {a : A} → singleton a ≢ ∅
+singleton-≢-∅ : ⦃ _ : Cs A ⦄ → {a : A} → singleton a ≢ ∅
 singleton-≢-∅ {A = A} {a = a} X≡∅ =
   case card-≡ᵉ (singleton a , singleton-strongly-finite)
                (∅ , ∅-strongly-finite)
@@ -222,7 +223,7 @@ singleton-≢-∅ {A = A} {a = a} X≡∅ =
     of λ ()
   where open IsEquivalence (≡ᵉ-isEquivalence {A}) renaming (refl to ≡ᵉ-refl)
 
-module _ {P Q : A → Type} {sp-P : specProperty P} {sp-Q : specProperty Q} where
+module _ ⦃ _ : Cs A ⦄ {P Q : A → Type} {sp-P : specProperty P} {sp-Q : specProperty Q} {X : Set A} where
 
   filter-∩ : filter sp-P (filter sp-Q X) ≡ᵉ filter (sp-∩ sp-P sp-Q) X
   filter-∩ = filter-∩-⊆ , filter-∩-⊇
@@ -236,9 +237,9 @@ module _ {P Q : A → Type} {sp-P : specProperty P} {sp-Q : specProperty Q} wher
       filter-∩-⊇ p with from ∈-filter p
       ... | ((Pa , Qa) , p) = to ∈-filter (Pa , (to ∈-filter (Qa , p)))
 
-module _ {P : A → Type} {sp-P : specProperty P} {Q : B → Type} {sp-Q : specProperty Q} where
+module _ ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄ {P : A → Type} {sp-P : specProperty P} {Q : B → Type} {sp-Q : specProperty Q} where
 
-  module _ {f : B → A} where
+  module _ {f : B → A} {X : Set B} where
     filter-map : filter sp-P (map f X) ≡ᵉ map f (filter (sp-∘ sp-P f) X)
     filter-map = filter-map-⊆ , filter-map-⊇
       where
@@ -252,7 +253,7 @@ module _ {P : A → Type} {sp-P : specProperty P} {Q : B → Type} {sp-Q : specP
         ... | (a , refl , p) with from ∈-filter p
         ... | (Pfa , p) = to ∈-filter (Pfa , (to ∈-map (a , refl , p)))
 
-module _ {P Q : A → Type} {sp-P : specProperty P} {sp-Q : specProperty Q} where
+module _ ⦃ _ : Cs A ⦄ {P Q : A → Type} {sp-P : specProperty P} {sp-Q : specProperty Q} {X : Set A} where
 
   import Relation.Unary as U
 
@@ -260,24 +261,24 @@ module _ {P Q : A → Type} {sp-P : specProperty P} {sp-Q : specProperty Q} wher
   filter-⇒-⊆ P⇒Q p with from ∈-filter p
   ... | (Pa , p) = to ∈-filter ((P⇒Q _ Pa) , p)
 
-module _ {P : A → Type} {sp-P : specProperty P} where
+module _ ⦃ _ : Cs A ⦄ {P : A → Type} {sp-P : specProperty P} where
 
-  filter-∅ : (∀ a → a ∈ X → ¬ P a) → filter sp-P X ≡ᵉ ∅
+  filter-∅ : {X : Set A} → (∀ a → a ∈ X → ¬ P a) → filter sp-P X ≡ᵉ ∅
   proj₁ (filter-∅ h) {a} h' with from ∈-filter h'
   ... | (Pa , a∈) = ⊥-elim (h a a∈ Pa)
   proj₂ (filter-∅ h) {a} h' = ⊥-elim (∉-∅ h')
 
-  filter-⊆ : filter sp-P X ⊆ X
+  filter-⊆ : {X : Set A} → filter sp-P X ⊆ X
   filter-⊆ = proj₂ ∘′ ∈⇔P
 
-  filter-pres-⊆ : X ⊆ Y → filter sp-P X ⊆ filter sp-P Y
+  filter-pres-⊆ : {X Y : Set A} → X ⊆ Y → filter sp-P X ⊆ filter sp-P Y
   filter-pres-⊆ xy a∈ = let Pa∈ = from ∈-filter a∈ in
     to ∈-filter (map₂ xy Pa∈)
 
-  filter-cong : X ≡ᵉ Y → filter sp-P X ≡ᵉ filter sp-P Y
+  filter-cong : {X Y : Set A} → X ≡ᵉ Y → filter sp-P X ≡ᵉ filter sp-P Y
   filter-cong (X⊆Y , Y⊆X) = filter-pres-⊆ X⊆Y , filter-pres-⊆ Y⊆X
 
-  filter-idem : filter sp-P (filter sp-P X) ≡ᵉ filter sp-P X
+  filter-idem : {X : Set A} → filter sp-P (filter sp-P X) ≡ᵉ filter sp-P X
   filter-idem {X = X} =
     begin
      filter sp-P (filter sp-P X)
@@ -289,38 +290,38 @@ module _ {P : A → Type} {sp-P : specProperty P} where
     where
       open import Relation.Binary.Reasoning.Setoid ≡ᵉ-Setoid
 
-  filter-split-∪ : ∀ {a} → a ∈ filter sp-P (X ∪ Y) → (P a × a ∈ X) ⊎ (P a × a ∈ Y)
+  filter-split-∪ : {X Y : Set A} → ∀ {a} → a ∈ filter sp-P (X ∪ Y) → (P a × a ∈ X) ⊎ (P a × a ∈ Y)
   filter-split-∪ a∈ = case (proj₁ (from ∈-filter a∈) , from ∈-∪ (proj₂ (from ∈-filter a∈))) of
     λ where
       (Pa , inj₁ a∈X) → inj₁ (Pa , a∈X)
       (Pa , inj₂ a∈Y) → inj₂ (Pa , a∈Y)
 
-  filter-hom-⊆ : filter sp-P (X ∪ Y) ⊆ filter sp-P X ∪ filter sp-P Y
+  filter-hom-⊆ : {X Y : Set A} → filter sp-P (X ∪ Y) ⊆ filter sp-P X ∪ filter sp-P Y
   filter-hom-⊆ {a = a} a∈ = to ∈-∪ (case filter-split-∪ a∈ of λ where
     (inj₁ v) → inj₁ (to ∈-filter v)
     (inj₂ v) → inj₂ (to ∈-filter v))
 
-  filter-hom-⊇ : filter sp-P X ∪ filter sp-P Y ⊆ filter sp-P (X ∪ Y)
+  filter-hom-⊇ : {X Y : Set A} → filter sp-P X ∪ filter sp-P Y ⊆ filter sp-P (X ∪ Y)
   filter-hom-⊇ a∈ = to ∈-filter (case (from ∈-∪ a∈) of λ where
        (inj₁ v) → proj₁ (from ∈-filter v) , to ∈-∪ (inj₁ (proj₂ (from ∈-filter v)))
        (inj₂ v) → proj₁ (from ∈-filter v) , to ∈-∪ (inj₂ (proj₂ (from ∈-filter v))) )
 
-  filter-hom-∪ : filter sp-P (X ∪ Y) ≡ᵉ (filter sp-P X) ∪ (filter sp-P Y)
+  filter-hom-∪ : {X Y : Set A} → filter sp-P (X ∪ Y) ≡ᵉ (filter sp-P X) ∪ (filter sp-P Y)
   filter-hom-∪ = filter-hom-⊆ , filter-hom-⊇
 
-Dec-∈-fromList : ∀ {a : A} → ⦃ DecEq A ⦄ → (l : List A) → Decidable¹ (_∈ fromList l)
+Dec-∈-fromList : ⦃ _ : Cs A ⦄ → ∀ {a : A} → ⦃ DecEq A ⦄ → (l : List A) → Decidable¹ (_∈ fromList l)
 Dec-∈-fromList _ _ = Relation.Nullary.Decidable.map ∈-fromList (_∈ˡ?_ _≟_ _ _)
 
-Dec-∈-singleton : ∀ {a : A} → ⦃ DecEq A ⦄ → Decidable¹ (_∈ ❴ a ❵)
+Dec-∈-singleton : ⦃ _ : Cs A ⦄ → ∀ {a : A} → ⦃ DecEq A ⦄ → Decidable¹ (_∈ ❴ a ❵)
 Dec-∈-singleton _ = Relation.Nullary.Decidable.map ∈-singleton (_ ≟ _)
 
-singleton-finite : ∀ {a : A} → finite ❴ a ❵
+singleton-finite : ⦃ _ : Cs A ⦄ → ∀ {a : A} → finite ❴ a ❵
 singleton-finite {a = a} = [ a ] , λ {x} →
   x ∈ ❴ a ❵  ∼⟨ R.SK-sym ∈-fromList ⟩
   x ∈ˡ [ a ] ∎
   where open R.EquationalReasoning
 
-filter-finite : ∀ {P : A → Type}
+filter-finite : ⦃ _ : Cs A ⦄ → ∀ {X : Set A} {P : A → Type}
               → (sp : specProperty P) → Decidable¹ P → finite X → finite (filter sp X)
 filter-finite {X = X} {P} sp P? (l , hl) = L.filter P? l , λ {a} →
   a ∈ filter sp X            ∼⟨ R.SK-sym ∈-filter ⟩
@@ -330,53 +331,53 @@ filter-finite {X = X} {P} sp P? (l , hl) = L.filter P? l , λ {a} →
   a ∈ˡ L.filter P? l ∎
   where open R.EquationalReasoning
 
-finite⇒A≡∅⊎∃a∈A : finite X → (X ≡ᵉ ∅) ⊎ ∃[ a ] a ∈ X
+finite⇒A≡∅⊎∃a∈A : ⦃ _ : Cs A ⦄ → {X : Set A} → finite X → (X ≡ᵉ ∅) ⊎ ∃[ a ] a ∈ X
 finite⇒A≡∅⊎∃a∈A ([]    , h) = inj₁ (∅-least (λ a∈A → case to h a∈A of λ ()))
 finite⇒A≡∅⊎∃a∈A (x ∷ _ , h) = inj₂ (x , from h (here refl))
 
-∪-⊆ˡ : X ⊆ X ∪ Y
+∪-⊆ˡ : ⦃ _ : Cs A ⦄ → {X Y : Set A} → X ⊆ X ∪ Y
 ∪-⊆ˡ = ∈⇔P ∘′ inj₁
 
-∪-⊆ʳ : Y ⊆ X ∪ Y
+∪-⊆ʳ : ⦃ _ : Cs A ⦄ → {X Y : Set A} → Y ⊆ X ∪ Y
 ∪-⊆ʳ = ∈⇔P ∘′ inj₂
 
-∪-⊆ : X ⊆ Z → Y ⊆ Z → X ∪ Y ⊆ Z
+∪-⊆ : ⦃ _ : Cs A ⦄ → {X Y Z : Set A} → X ⊆ Z → Y ⊆ Z → X ∪ Y ⊆ Z
 ∪-⊆ X⊆Z Y⊆Z = λ a∈X∪Y → [ X⊆Z , Y⊆Z ]′ (∈⇔P a∈X∪Y)
 
-⊆→∪ : X ⊆ Y → X ∪ Y ≡ᵉ Y
+⊆→∪ : ⦃ _ : Cs A ⦄ → {X Y : Set A} → X ⊆ Y → X ∪ Y ≡ᵉ Y
 ⊆→∪ X⊆Y = (λ {a} x → case from ∈-∪ x of λ where
             (inj₁ v) → X⊆Y v
             (inj₂ v) → v) , ∪-⊆ʳ
 
-∪-Supremum : Supremum (_⊆_ {A}) _∪_
+∪-Supremum : ⦃ _ : Cs A ⦄ → Supremum (_⊆_ {A}) _∪_
 ∪-Supremum _ _ = ∪-⊆ˡ , ∪-⊆ʳ , λ _ → ∪-⊆
 
-∪-cong-⊆ : _∪_ {A} Preserves₂ _⊆_ ⟶ _⊆_ ⟶ _⊆_
+∪-cong-⊆ : ⦃ _ : Cs A ⦄ → _∪_ {A} Preserves₂ _⊆_ ⟶ _⊆_ ⟶ _⊆_
 ∪-cong-⊆ X⊆X' Y⊆Y' = ∈⇔P ∘′ (⊎.map X⊆X' Y⊆Y') ∘′ ∈⇔P
 
-∪-cong : _∪_ {A} Preserves₂ _≡ᵉ_ ⟶ _≡ᵉ_ ⟶ _≡ᵉ_
+∪-cong : ⦃ _ : Cs A ⦄ → _∪_ {A} Preserves₂ _≡ᵉ_ ⟶ _≡ᵉ_ ⟶ _≡ᵉ_
 ∪-cong = cong-⊆⇒cong₂ ∪-cong-⊆
 
-∪-preserves-finite : _∪_ {A} Preservesˢ₂ finite
-∪-preserves-finite {a = X} {Y} (l , hX) (l' , hY) = (l ++ l') , λ {a} →
+∪-preserves-finite : ⦃ _ : Cs A ⦄ → ∀ {X Y : Set A} → finite X → finite Y → finite (X ∪ Y)
+∪-preserves-finite {X = X} {Y} (l , hX) (l' , hY) = (l ++ l') , λ {a} →
   a ∈ X ∪ Y          ∼⟨ R.SK-sym ∈-∪ ⟩
   (a ∈ X ⊎ a ∈ Y)    ∼⟨ hX ⊎-cong hY ⟩
   (a ∈ˡ l ⊎ a ∈ˡ l') ∼⟨ mk⇔ ⊎.[ ∈-++⁺ˡ , ∈-++⁺ʳ _ ] (∈-++⁻ _) ⟩
   a ∈ˡ l ++ l'       ∎
   where open R.EquationalReasoning
 
-∪-sym : X ∪ Y ≡ᵉ Y ∪ X
+∪-sym : ⦃ _ : Cs A ⦄ → {X Y : Set A} → X ∪ Y ≡ᵉ Y ∪ X
 ∪-sym = ∪-⊆ ∪-⊆ʳ ∪-⊆ˡ , ∪-⊆ ∪-⊆ʳ ∪-⊆ˡ
 
-Set-JoinSemilattice : IsJoinSemilattice (_≡ᵉ_ {A}) _⊆_ _∪_
+Set-JoinSemilattice : ⦃ _ : Cs A ⦄ → IsJoinSemilattice (_≡ᵉ_ {A}) _⊆_ _∪_
 Set-JoinSemilattice = record
   { isPartialOrder = ⊆-PartialOrder ; supremum = ∪-Supremum }
 
-Set-BoundedJoinSemilattice : IsBoundedJoinSemilattice (_≡ᵉ_ {A}) _⊆_ _∪_ ∅
+Set-BoundedJoinSemilattice : ⦃ _ : Cs A ⦄ → IsBoundedJoinSemilattice (_≡ᵉ_ {A}) _⊆_ _∪_ ∅
 Set-BoundedJoinSemilattice = record
   { isJoinSemilattice = Set-JoinSemilattice ; minimum = ∅-minimum }
 
-Set-BddSemilattice : {A : Type ℓ} → BoundedJoinSemilattice _ _ _
+Set-BddSemilattice : {A : Type ℓ} → ⦃ _ : Cs A ⦄ → BoundedJoinSemilattice _ _ _
 Set-BddSemilattice {A} = record
                       { Carrier = Set A
                       ; _≈_ = _≡ᵉ_ {A}
@@ -386,7 +387,7 @@ Set-BddSemilattice {A} = record
                       ; isBoundedJoinSemilattice = Set-BoundedJoinSemilattice
                       }
 
-module _ {A : Type ℓ} where
+module _ {A : Type ℓ} ⦃ _ : Cs A ⦄ where
   open Bounded∨Semilattice (Set-BddSemilattice {A})
   open ∨Semilattice (BoundedJoinSemilattice.joinSemilattice (Set-BddSemilattice {A}))
     using (∨-comm; ∨-assoc)
@@ -403,7 +404,7 @@ module _ {A : Type ℓ} where
   ∪-assoc : (X Y Z : Set A) → (X ∪ Y) ∪ Z ≡ᵉ X ∪ (Y ∪ Z)
   ∪-assoc = ∨-assoc
 
-fromList-∪-singleton : {A : Type ℓ} {x : A} {l : List A} → fromList (x ∷ l) ≡ᵉ ❴ x ❵ ∪ fromList l
+fromList-∪-singleton : {A : Type ℓ} → ⦃ _ : Cs A ⦄ → {x : A} {l : List A} → fromList (x ∷ l) ≡ᵉ ❴ x ❵ ∪ fromList l
 fromList-∪-singleton .proj₁ h with from ∈-fromList h
 ... | here refl = ∈-∪⁺ (inj₁ (to ∈-fromList (here refl)))
 ... | there q = ∈-∪⁺ (inj₂ (to ∈-fromList q))
@@ -411,7 +412,7 @@ fromList-∪-singleton .proj₂ h with ∈-∪⁻ h
 ... | (inj₁ a∈) = to ∈-fromList (here (from ∈-singleton a∈))
 ... | (inj₂ a∈) = to ∈-fromList (there (from ∈-fromList a∈))
 
-∪-fromList-++ : (ll lr : List A) → fromList ll ∪ fromList lr ≡ᵉ fromList (ll ++ lr)
+∪-fromList-++ : ⦃ _ : Cs A ⦄ → (ll lr : List A) → fromList ll ∪ fromList lr ≡ᵉ fromList (ll ++ lr)
 ∪-fromList-++ [] lr = ∪-identityˡ (fromList lr)
 ∪-fromList-++ (x ∷ l) lr =
   begin
@@ -424,34 +425,34 @@ fromList-∪-singleton .proj₂ h with ∈-∪⁻ h
   module ≡ᵉ = IsEquivalence (≡ᵉ-isEquivalence)
   open import Relation.Binary.Reasoning.Setoid ≡ᵉ-Setoid
 
-disjoint-sym : disjoint X Y → disjoint Y X
+disjoint-sym : ⦃ _ : Cs A ⦄ → {X Y : Set A} → disjoint X Y → disjoint Y X
 disjoint-sym disj = flip disj
 
-disjoint-subst : disjoint X Y → X ≡ᵉ Z → disjoint Z Y
+disjoint-subst : ⦃ _ : Cs A ⦄ → {X Y Z : Set A} → disjoint X Y → X ≡ᵉ Z → disjoint Z Y
 disjoint-subst disj X≡Z = disj ∘ (proj₂ X≡Z)
 
-module Intersectionᵖ (sp-∈ : spec-∈ A) where
+module Intersectionᵖ ⦃ _ : Cs A ⦄ (sp-∈ : spec-∈ A) where
   open Intersection sp-∈
 
-  disjoint⇒disjoint' : disjoint X Y → disjoint' X Y
+  disjoint⇒disjoint' : {X Y : Set A} → disjoint X Y → disjoint' X Y
   disjoint⇒disjoint' h = ∅-least (⊥-elim ∘ uncurry h ∘ from ∈-∩)
 
-  disjoint'⇒disjoint : disjoint' X Y → disjoint X Y
+  disjoint'⇒disjoint : {X Y : Set A} → disjoint' X Y → disjoint X Y
   disjoint'⇒disjoint h a∈X a∈Y = ∉-∅ (to (to ≡ᵉ⇔≡ᵉ' h _) (to ∈-∩ (a∈X , a∈Y)))
 
-  ∩-⊆ˡ : X ∩ Y ⊆ X
+  ∩-⊆ˡ : {X Y : Set A} → X ∩ Y ⊆ X
   ∩-⊆ˡ = proj₁ ∘ from ∈-∩
 
-  ∩-⊆ʳ : X ∩ Y ⊆ Y
+  ∩-⊆ʳ : {X Y : Set A} → X ∩ Y ⊆ Y
   ∩-⊆ʳ = proj₂ ∘ from ∈-∩
 
-  ∩-⊆ : Z ⊆ X → Z ⊆ Y → Z ⊆ X ∩ Y
+  ∩-⊆ : {X Y Z : Set A} → Z ⊆ X → Z ⊆ Y → Z ⊆ X ∩ Y
   ∩-⊆ Z⊆X Z⊆Y = λ x∈Z → to ∈-∩ (< Z⊆X , Z⊆Y > x∈Z)
 
   ∩-Infimum : Infimum _⊆_ _∩_
   ∩-Infimum X Y = ∩-⊆ˡ , ∩-⊆ʳ , λ _ → ∩-⊆
 
-  ∩-preserves-finite : _∩_ Preservesˢ₂ weakly-finite
+  ∩-preserves-finite : ∀ {X Y : Set A} → weakly-finite X → weakly-finite Y → weakly-finite (X ∩ Y)
   ∩-preserves-finite _ = ⊆-weakly-finite ∩-⊆ʳ
 
   ∩-cong-⊆ : _∩_ Preserves₂ _⊆_ ⟶ _⊆_ ⟶ _⊆_
@@ -471,15 +472,15 @@ module Intersectionᵖ (sp-∈ : spec-∈ A) where
   Set-Lattice = record
     { isPartialOrder = ⊆-PartialOrder ; supremum = ∪-Supremum ; infimum = ∩-Infimum }
 
-  ∩-sym⊆ : X ∩ Y ⊆ Y ∩ X
+  ∩-sym⊆ : {X Y : Set A} → X ∩ Y ⊆ Y ∩ X
   ∩-sym⊆ a∈X∩Y with from ∈-∩ a∈X∩Y
   ... | a∈X , a∈Y = to ∈-∩ (a∈Y , a∈X)
 
-  ∩-sym : X ∩ Y ≡ᵉ Y ∩ X
+  ∩-sym : {X Y : Set A} → X ∩ Y ≡ᵉ Y ∩ X
   ∩-sym = ∩-sym⊆ , ∩-sym⊆
 
 -- Additional properties of lists and sets.
-module _ {L : List A} where
+module _ ⦃ _ : Cs A ⦄ {L : List A} where
   open Equivalence
 
   sublist-⇔ : {l : List A} → fromList l ⊆ fromList L ⇔ l ⊆ˡ L

--- a/src/Axiom/Set/Rel.agda
+++ b/src/Axiom/Set/Rel.agda
@@ -4,13 +4,13 @@
 open import abstract-set-theory.Prelude hiding (map)
 open import Axiom.Set using (Theory)
 
-module Axiom.Set.Rel (th : Theory) where
+module Axiom.Set.Rel {ℓ} {ℓ_c} (th : Theory {ℓ} {ℓ_c}) where
 
 import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 import Function.Related.Propositional as R
 
 open Theory th
-open import Axiom.Set.Properties th
+open import Axiom.Set.Properties {ℓ} {ℓ_c} th
 
 import Data.Product as ×
 open import Data.List.Ext.Properties using (_⊎-cong_)
@@ -25,8 +25,6 @@ open import Tactic.Defaults
 
 open Equivalence
 
-infix 10 _⁻¹ʳ
-
 -- Because of missing macro hygiene, we have to copy&paste this.
 -- c.f. https://github.com/agda/agda/issues/3819
 private macro
@@ -38,271 +36,295 @@ private macro
     ( quote ∈-filter⁻' ∷ quote ∈-∪⁻ ∷ quote ∈-map⁻' ∷ quote ∈-fromList⁻
     ∷ quote ∈-filter⁺' ∷ quote ∈-∪⁺ ∷ quote ∈-map⁺' ∷ quote ∈-fromList⁺ ∷ [])
 
-Rel : Type → Type → Type
+Rel : (A B : Type ℓ) → ⦃ Cs A ⦄ → ⦃ Cs B ⦄ → Type ℓ
 Rel A B = Set (A × B)
 
-private variable A A' B B' C : Type
-                 R R' : Rel A B
-                 X : Set A
+private variable A A' B B' C : Type ℓ
 
-relatedˡ : Rel A B → Set A
-relatedˡ = map proj₁
+module _ ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄ where
 
-∅ʳ : Rel A B
-∅ʳ = ∅
+  relatedˡ : Rel A B → Set A
+  relatedˡ = map proj₁
 
-dom : Rel A B → Set A
-dom = map proj₁
+  ∅ʳ : Rel A B
+  ∅ʳ = ∅
 
-range : Rel A B → Set B
-range = map proj₂
+  dom : Rel A B → Set A
+  dom = map proj₁
 
-_⁻¹ʳ : {A B : Type} → Rel A B → Rel B A
-R ⁻¹ʳ = map swap R
-  where open import Data.Product using (swap)
+  range : Rel A B → Set B
+  range = map proj₂
 
-⁻¹ʳ-cong : {A B : Type} {R S : Rel A B}
-         → R ≡ᵉ S → R ⁻¹ʳ ≡ᵉ S ⁻¹ʳ
-⁻¹ʳ-cong = map-≡ᵉ
+  infix 10 _⁻¹ʳ
+  _⁻¹ʳ : Rel A B → Rel B A
+  R ⁻¹ʳ = map swap R
+    where open import Data.Product using (swap)
 
-disjoint-dom⇒disjoint : disjoint (dom R) (dom R') → disjoint R R'
-disjoint-dom⇒disjoint disj = ∈-map⁺'' -⟨ disj ⟩- ∈-map⁺''
+  ⁻¹ʳ-cong : {R S : Rel A B}
+           → R ≡ᵉ S → R ⁻¹ʳ ≡ᵉ S ⁻¹ʳ
+  ⁻¹ʳ-cong = map-≡ᵉ
 
-_∣'_ : {P : A → Type} → Rel A B → specProperty P → Rel A B
-m ∣' P? = filter (sp-∘ P? proj₁) m
+  disjoint-dom⇒disjoint : {R R' : Rel A B} → disjoint (dom R) (dom R') → disjoint R R'
+  disjoint-dom⇒disjoint disj = ∈-map⁺'' -⟨ disj ⟩- ∈-map⁺''
 
-_∣^'_ : {P : B → Type} → Rel A B → specProperty P → Rel A B
-m ∣^' P? = filter (sp-∘ P? proj₂) m
+  _∣'_ : {P : A → Type} → Rel A B → specProperty P → Rel A B
+  m ∣' P? = filter (sp-∘ P? proj₁) m
 
-impl⇒res⊆ : ∀ {X : Rel A B} {P P'} (sp-P : specProperty P) (sp-P' : specProperty P')
-          → (∀ {a} → P a → P' a) → X ∣' sp-P ⊆ X ∣' sp-P'
-impl⇒res⊆ sp-P sp-P' P⇒P' a∈X∣'P = ∈⇔P (×.map₁ P⇒P' (∈⇔P a∈X∣'P))
+  _∣^'_ : {P : B → Type} → Rel A B → specProperty P → Rel A B
+  m ∣^' P? = filter (sp-∘ P? proj₂) m
 
-impl⇒cores⊆ : ∀ {X : Rel A B} {P P'} (sp-P : specProperty P) (sp-P' : specProperty P')
-            → (∀ {b} → P b → P' b) → X ∣^' sp-P ⊆ X ∣^' sp-P'
-impl⇒cores⊆ sp-P sp-P' P⇒P' a∈X∣^'P = ∈⇔P (×.map₁ P⇒P' (∈⇔P a∈X∣^'P))
+  impl⇒res⊆ : ∀ {X : Rel A B} {P P'} (sp-P : specProperty P) (sp-P' : specProperty P')
+            → (∀ {a} → P a → P' a) → X ∣' sp-P ⊆ X ∣' sp-P'
+  impl⇒res⊆ sp-P sp-P' P⇒P' a∈X∣'P = ∈⇔P (×.map₁ P⇒P' (∈⇔P a∈X∣'P))
 
-mapˡ : (A → A') → Rel A B → Rel A' B
-mapˡ f R = map (×.map₁ f) R
+  impl⇒cores⊆ : ∀ {X : Rel A B} {P P'} (sp-P : specProperty P) (sp-P' : specProperty P')
+              → (∀ {b} → P b → P' b) → X ∣^' sp-P ⊆ X ∣^' sp-P'
+  impl⇒cores⊆ sp-P sp-P' P⇒P' a∈X∣^'P = ∈⇔P (×.map₁ P⇒P' (∈⇔P a∈X∣^'P))
 
-mapʳ : (B → B') → Rel A B → Rel A B'
-mapʳ f R = map (×.map₂ f) R
+  mapˡ : ⦃ _ : Cs A' ⦄ → (A → A') → Rel A B → Rel A' B
+  mapˡ f R = map (×.map₁ f) R
 
-dom∈ : ∀ {a} → (∃[ b ] (a , b) ∈ R) ⇔ a ∈ dom R
-dom∈ {R = R} {a} =
-  (∃[ b ] (a , b) ∈ R)            ∼⟨ R.SK-sym (mk⇔ (λ { ((_ , y) , refl , ay∈R) → y , ay∈R })
-                                              (λ (x , ax∈R) → (a , x) , refl , ax∈R)) ⟩
-  (∃[ a₁ ] a ≡ proj₁ a₁ × a₁ ∈ R) ∼⟨ ∈-map ⟩
+  mapʳ : ⦃ _ : Cs B' ⦄ → (B → B') → Rel A B → Rel A B'
+  mapʳ f R = map (×.map₂ f) R
 
-  a ∈ dom R                       ∎
-  where open R.EquationalReasoning
+  dom∈ : ∀ {R : Rel A B} {a} → (∃[ b ] (a , b) ∈ R) ⇔ a ∈ dom R
+  dom∈ {R = R} {a} =
+    (∃[ b ] (a , b) ∈ R)            ∼⟨ R.SK-sym (mk⇔ (λ { ((_ , y) , refl , ay∈R) → y , ay∈R })
+                                                (λ (x , ax∈R) → (a , x) , refl , ax∈R)) ⟩
+    (∃[ a₁ ] a ≡ proj₁ a₁ × a₁ ∈ R) ∼⟨ ∈-map ⟩
 
-module _ {x : A} {y : B} where
-  module _ {a : A} where
-    ∈-dom-singleton-pair : a ≡ x ⇔ a ∈ dom ❴ x , y ❵
-    ∈-dom-singleton-pair = mk⇔ (λ a≡x → to dom∈ (y , to ∈-singleton (×-≡,≡→≡ (a≡x , refl))))
-                               (,-injectiveˡ ∘ from ∈-singleton ∘ proj₂ ∘ from dom∈)
+    a ∈ dom R                       ∎
+    where open R.EquationalReasoning
 
-    dom-single→single : a ∈ dom ❴ x , y ❵ → a ∈ ❴ x ❵
-    dom-single→single = to ∈-singleton ∘ from ∈-dom-singleton-pair
+  module _ {x : A} {y : B} where
+    module _ {a : A} where
+      ∈-dom-singleton-pair : a ≡ x ⇔ a ∈ dom ❴ x , y ❵
+      ∈-dom-singleton-pair = mk⇔ (λ a≡x → to dom∈ (y , to ∈-singleton (×-≡,≡→≡ (a≡x , refl))))
+                                 (,-injectiveˡ ∘ from ∈-singleton ∘ proj₂ ∘ from dom∈)
 
-    single→dom-single : a ∈ ❴ x ❵ → a ∈ dom ❴ x , y ❵
-    single→dom-single = to ∈-dom-singleton-pair ∘ from ∈-singleton
+      dom-single→single : a ∈ dom ❴ x , y ❵ → a ∈ ❴ x ❵
+      dom-single→single = to ∈-singleton ∘ from ∈-dom-singleton-pair
 
-  dom-single≡single : dom ❴ x , y ❵ ≡ᵉ ❴ x ❵
-  dom-single≡single = dom-single→single , single→dom-single
+      single→dom-single : a ∈ ❴ x ❵ → a ∈ dom ❴ x , y ❵
+      single→dom-single = to ∈-dom-singleton-pair ∘ from ∈-singleton
 
-∈-dom : {a : A × B} → a ∈ R → proj₁ a ∈ dom R
-∈-dom {a = a} a∈ = to ∈-map (a , (refl , a∈))
+    dom-single≡single : dom ❴ x , y ❵ ≡ᵉ ❴ x ❵
+    dom-single≡single = dom-single→single , single→dom-single
 
-∉-dom∅ : {a : A} → a ∉ dom{A}{B} ∅
-∉-dom∅ {a} a∈dom∅ = ⊥-elim $ ∉-∅ $ proj₂ $ (from dom∈) a∈dom∅
+  ∈-dom : {a : A × B} {R : Rel A B} → a ∈ R → proj₁ a ∈ dom R
+  ∈-dom {a = a} a∈ = to ∈-map (a , (refl , a∈))
 
-dom∅ : dom{A}{B} ∅ ≡ᵉ ∅
-dom∅ = ⊥-elim ∘ ∉-dom∅ , ∅-minimum (dom ∅)
+  ∉-dom∅ : {a : A} → a ∉ dom (∅ {A = A × B})
+  ∉-dom∅ {a} a∈dom∅ = ⊥-elim $ ∉-∅ $ proj₂ $ (from dom∈) a∈dom∅
 
-dom∪ : dom (R ∪ R') ≡ᵉ dom R ∪ dom R'
-dom∪ {R = R} {R'} = from ≡ᵉ⇔≡ᵉ' λ a →
-  a ∈ dom (R ∪ R')                           ∼⟨ R.SK-sym dom∈ ⟩
-  (∃[ b ] (a , b) ∈ R ∪ R')                  ∼⟨ ∃-cong′ (R.SK-sym ∈-∪) ⟩
-  (∃[ b ] ((a , b) ∈ R ⊎ (a , b) ∈ R'))      ↔⟨ ∃-distrib-⊎ ⟩
-  (∃[ b ] (a , b) ∈ R ⊎ ∃[ b ] (a , b) ∈ R') ∼⟨ dom∈ ⊎-cong dom∈ ⟩
-  (a ∈ dom R ⊎ a ∈ dom R')                   ∼⟨ ∈-∪ ⟩
-  a ∈ dom R ∪ dom R'                         ∎
-  where open R.EquationalReasoning
+  dom∅ : dom (∅ {A = A × B}) ≡ᵉ ∅
+  dom∅ = ⊥-elim ∘ ∉-dom∅ , ∅-minimum (dom ∅)
 
-dom⊆ : dom{A}{B} Preserves _⊆_ ⟶ _⊆_
-dom⊆ R⊆R' a∈ = to dom∈ $ proj₁ (from dom∈ a∈) , R⊆R' (proj₂ (from dom∈ a∈))
+  dom∪ : {R R' : Rel A B} → dom (R ∪ R') ≡ᵉ dom R ∪ dom R'
+  dom∪ {R = R} {R'} = from ≡ᵉ⇔≡ᵉ' λ a →
+    a ∈ dom (R ∪ R')                           ∼⟨ R.SK-sym dom∈ ⟩
+    (∃[ b ] (a , b) ∈ R ∪ R')                  ∼⟨ ∃-cong′ (R.SK-sym ∈-∪) ⟩
+    (∃[ b ] ((a , b) ∈ R ⊎ (a , b) ∈ R'))      ↔⟨ ∃-distrib-⊎ ⟩
+    (∃[ b ] (a , b) ∈ R ⊎ ∃[ b ] (a , b) ∈ R') ∼⟨ dom∈ ⊎-cong dom∈ ⟩
+    (a ∈ dom R ⊎ a ∈ dom R')                   ∼⟨ ∈-∪ ⟩
+    a ∈ dom R ∪ dom R'                         ∎
+    where open R.EquationalReasoning
 
-dom-cong : R ≡ᵉ R' → dom R ≡ᵉ dom R'
-dom-cong RR' = (dom⊆ (proj₁ RR')) , (dom⊆ (proj₂ RR'))
+  dom⊆ : dom Preserves _⊆_ ⟶ _⊆_
+  dom⊆ R⊆R' a∈ = to dom∈ $ proj₁ (from dom∈ a∈) , R⊆R' (proj₂ (from dom∈ a∈))
 
-dom-⊆mapʳ : {f : B → B'} → dom R ⊆ dom (mapʳ f R)
+  dom-cong : {R R' : Rel A B} → R ≡ᵉ R' → dom R ≡ᵉ dom R'
+  dom-cong RR' = (dom⊆ (proj₁ RR')) , (dom⊆ (proj₂ RR'))
+
+dom-⊆mapʳ : ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄ ⦃ _ : Cs B' ⦄
+  → {R : Rel A B} {f : B → B'} → dom R ⊆ dom (mapʳ f R)
 dom-⊆mapʳ {f = f} {a} a∈domR with from dom∈ a∈domR
 ... | b , ab∈R = to dom∈ (f b , to ∈-map ((a , b) , refl , ab∈R))
 
-dom-mapʳ⊆ : {f : B → B'} → dom (mapʳ f R) ⊆ dom R
+dom-mapʳ⊆ : ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄ ⦃ _ : Cs B' ⦄
+  → {R : Rel A B} {f : B → B'} → dom (mapʳ f R) ⊆ dom R
 dom-mapʳ⊆ a∈dmR with from dom∈ a∈dmR
 ... | _ , p∈map with from ∈-map p∈map
 ... | (_ , b) , refl , ab∈R = to dom∈ (b , ab∈R)
 
-mapʳ-dom : {f : B → B'} → dom R ≡ᵉ dom (mapʳ f R)
+mapʳ-dom : ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄ ⦃ _ : Cs B' ⦄
+  → {R : Rel A B} {f : B → B'} → dom R ≡ᵉ dom (mapʳ f R)
 mapʳ-dom = dom-⊆mapʳ , dom-mapʳ⊆
 
-dom-mapˡ≡map-dom : {f : A → A'} → dom (mapˡ f R) ≡ᵉ map f (dom R)
+dom-mapˡ≡map-dom : ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄ ⦃ _ : Cs A' ⦄
+  → {R : Rel A B} {f : A → A'} → dom (mapˡ f R) ≡ᵉ map f (dom R)
 dom-mapˡ≡map-dom .proj₁ a'∈dom with from ∈-map (proj₂ (from dom∈ a'∈dom))
 ... | (a , b) , a'b≡fab , ab∈R = to ∈-map (a , proj₁ (×-≡,≡←≡ a'b≡fab) , to dom∈ (b , ab∈R))
 dom-mapˡ≡map-dom .proj₂ a'∈map with from ∈-map a'∈map
 ... | a , a'≡fa , a∈domR with from dom∈ a∈domR
 ... | b , ab∈R = to dom∈ (b , to ∈-map ((a , b) , ×-≡,≡→≡ (a'≡fa , refl) , ab∈R))
 
-dom-∅ : dom R ⊆ ∅ → R ≡ᵉ ∅
-dom-∅ dom⊆∅ = ∅-least (λ {x} x∈R → ⊥-elim $ ∉-∅ $ dom⊆∅ $ to dom∈ (-, x∈R))
+module _ ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄ where
 
-mapPartialLiftKey : (A → B → Maybe B') → A × B → Maybe (A × B')
-mapPartialLiftKey f (k , v) = map? (k ,_) (f k v)
+  dom-∅ : {R : Rel A B} → dom R ⊆ ∅ → R ≡ᵉ ∅
+  dom-∅ dom⊆∅ = ∅-least (λ {x} x∈R → ⊥-elim $ ∉-∅ $ dom⊆∅ $ to dom∈ (-, x∈R))
 
-mapPartialLiftKey-map : ∀ {a : A} {b' : B'} {f : A → B → Maybe B'} {r : Rel A B}
-  → just (a , b') ∈ map (mapPartialLiftKey f) r
-  → ∃[ b ] just b' ≡ f a b × (a , b) ∈ r
-mapPartialLiftKey-map {f = f} ab∈m
-  with from ∈-map ab∈m
-... | (a' , b') , ≡ , a'b'∈r
-  with f a' b' in eq
-mapPartialLiftKey-map {f = f} ab∈m | (a' , b') , refl , a'b'∈r | just x
-  = b' , sym eq , a'b'∈r
+  mapPartialLiftKey : (A → B → Maybe B') → A × B → Maybe (A × B')
+  mapPartialLiftKey f (k , v) = map? (k ,_) (f k v)
 
-mapMaybeWithKey : (A → B → Maybe B') → Rel A B → Rel A B'
-mapMaybeWithKey f r = mapPartial (mapPartialLiftKey f) r
+  mapPartialLiftKey-map : ⦃ _ : Cs B' ⦄
+    → ∀ {a : A} {b' : B'} {f : A → B → Maybe B'} {r : Rel A B}
+    → just (a , b') ∈ map (mapPartialLiftKey f) r
+    → ∃[ b ] just b' ≡ f a b × (a , b) ∈ r
+  mapPartialLiftKey-map {f = f} ab∈m
+    with from ∈-map ab∈m
+  ... | (a' , b') , ≡ , a'b'∈r
+    with f a' b' in eq
+  mapPartialLiftKey-map {f = f} ab∈m | (a' , b') , refl , a'b'∈r | just x
+    = b' , sym eq , a'b'∈r
 
-∈-mapMaybeWithKey : ∀ {a : A} {b' : B'} {f : A → B → Maybe B'} {r : Rel A B}
-  → (a , b') ∈ mapMaybeWithKey f r
-  → ∃[ b ] (just b' ≡ f a b × (a , b) ∈ r)
-∈-mapMaybeWithKey {a = a} {b'} {f} ab'∈
-  = mapPartialLiftKey-map {f = f}
-  $ ⊆-mapPartial
-  $ to (∈-map {f = just}) ((a , b') , refl , ab'∈)
+  mapMaybeWithKey : ⦃ _ : Cs B' ⦄ → (A → B → Maybe B') → Rel A B → Rel A B'
+  mapMaybeWithKey f r = mapPartial (mapPartialLiftKey f) r
 
-module Restriction (sp-∈ : spec-∈ A) where
+  ∈-mapMaybeWithKey : ⦃ _ : Cs B' ⦄
+    → ∀ {a : A} {b' : B'} {f : A → B → Maybe B'} {r : Rel A B}
+    → (a , b') ∈ mapMaybeWithKey f r
+    → ∃[ b ] (just b' ≡ f a b × (a , b) ∈ r)
+  ∈-mapMaybeWithKey {a = a} {b'} {f} ab'∈
+    = mapPartialLiftKey-map {f = f}
+    $ ⊆-mapPartial
+    $ to (∈-map {f = just}) ((a , b') , refl , ab'∈)
 
-  _∣_ : Rel A B → Set A → Rel A B
-  m ∣ X = m ∣' sp-∈ {X}
+  module Restriction (sp-∈ : spec-∈ A) where
 
-  _∣_ᶜ : Rel A B → Set A → Rel A B
-  m ∣ X ᶜ = m ∣' sp-¬ (sp-∈ {X})
+    _∣_ : Rel A B → Set A → Rel A B
+    m ∣ X = m ∣' sp-∈ {X}
 
-  _⟪$⟫_ : Rel A B → Set A → Set B
-  m ⟪$⟫ X = range (m ∣ X)
+    _∣_ᶜ : Rel A B → Set A → Rel A B
+    m ∣ X ᶜ = m ∣' sp-¬ (sp-∈ {X})
 
-  res-cong : (R ∣_) Preserves _≡ᵉ_ ⟶ _≡ᵉ_
-  res-cong (X⊆Y , Y⊆X) = (λ ∈R∣X → ∈⇔P (×.map₁ X⊆Y (∈⇔P ∈R∣X)))
-                       , (λ ∈R∣Y → ∈⇔P (×.map₁ Y⊆X (∈⇔P ∈R∣Y)))
+    _⟪$⟫_ : Rel A B → Set A → Set B
+    m ⟪$⟫ X = range (m ∣ X)
 
-  res-dom : dom (R ∣ X) ⊆ X
-  res-dom a∈dom with ∈⇔P a∈dom
-  ... | _ , refl , h = proj₁ $ ∈⇔P h
+    res-cong : {R : Rel A B} → (R ∣_) Preserves _≡ᵉ_ ⟶ _≡ᵉ_
+    res-cong (X⊆Y , Y⊆X) = (λ ∈R∣X → ∈⇔P (×.map₁ X⊆Y (∈⇔P ∈R∣X)))
+                         , (λ ∈R∣Y → ∈⇔P (×.map₁ Y⊆X (∈⇔P ∈R∣Y)))
 
-  res-domᵐ : dom (R ∣ X) ⊆ dom R
-  res-domᵐ a∈dom with ∈⇔P a∈dom
-  ... | _ , refl , h = ∈-map⁺'' $ proj₂ (∈⇔P h)
+    res-dom : {R : Rel A B} {X : Set A} → dom (R ∣ X) ⊆ X
+    res-dom a∈dom with ∈⇔P a∈dom
+    ... | _ , refl , h = proj₁ $ ∈⇔P h
 
-  res-comp-cong : (R ∣_ᶜ) Preserves _≡ᵉ_ ⟶ _≡ᵉ_
-  res-comp-cong (X⊆Y , Y⊆X) = (λ ∈R∣X → ∈⇔P (×.map₁ (_∘ Y⊆X) (∈⇔P ∈R∣X)))
-                            , (λ ∈R∣Y → ∈⇔P (×.map₁ (_∘ X⊆Y) (∈⇔P ∈R∣Y)))
+    res-domᵐ : {R : Rel A B} {X : Set A} → dom (R ∣ X) ⊆ dom R
+    res-domᵐ a∈dom with ∈⇔P a∈dom
+    ... | _ , refl , h = ∈-map⁺'' $ proj₂ (∈⇔P h)
 
-  res-comp-dom : ∀ {a} → a ∈ dom (R ∣ X ᶜ) → a ∉ X
-  res-comp-dom a∈dom with ∈⇔P a∈dom
-  ... | _ , refl , h = proj₁ $ ∈⇔P h
+    res-comp-cong : {R : Rel A B} → (R ∣_ᶜ) Preserves _≡ᵉ_ ⟶ _≡ᵉ_
+    res-comp-cong (X⊆Y , Y⊆X) = (λ ∈R∣X → ∈⇔P (×.map₁ (_∘ Y⊆X) (∈⇔P ∈R∣X)))
+                              , (λ ∈R∣Y → ∈⇔P (×.map₁ (_∘ X⊆Y) (∈⇔P ∈R∣Y)))
 
-  res-comp-domᵐ : dom (R ∣ X ᶜ) ⊆ dom R
-  res-comp-domᵐ a∈dom with ∈⇔P a∈dom
-  ... | _ , refl , h = ∈-map⁺'' (proj₂ (∈⇔P h))
+    res-comp-dom : {R : Rel A B} {X : Set A} → ∀ {a} → a ∈ dom (R ∣ X ᶜ) → a ∉ X
+    res-comp-dom a∈dom with ∈⇔P a∈dom
+    ... | _ , refl , h = proj₁ $ ∈⇔P h
 
-  res-⊆ : (R ∣ X) ⊆ R
-  res-⊆ = proj₂ ∘′ ∈⇔P
+    res-comp-domᵐ : {R : Rel A B} {X : Set A} → dom (R ∣ X ᶜ) ⊆ dom R
+    res-comp-domᵐ a∈dom with ∈⇔P a∈dom
+    ... | _ , refl , h = ∈-map⁺'' (proj₂ (∈⇔P h))
 
-  ex-⊆ : (R ∣ X ᶜ) ⊆ R
-  ex-⊆ = proj₂ ∘′ ∈⇔P
+    res-⊆ : {R : Rel A B} {X : Set A} → (R ∣ X) ⊆ R
+    res-⊆ = proj₂ ∘′ ∈⇔P
 
-  res-∅ : R ∣ ∅ ≡ᵉ ∅
-  res-∅ = dom-∅ res-dom
+    ex-⊆ : {R : Rel A B} {X : Set A} → (R ∣ X ᶜ) ⊆ R
+    ex-⊆ = proj₂ ∘′ ∈⇔P
 
-  res-∅ᶜ : R ∣ ∅ ᶜ ≡ᵉ R
-  res-∅ᶜ = ex-⊆ , λ a∈R → ∈⇔P (∉-∅ , a∈R)
+    res-∅ : {R : Rel A B} → R ∣ ∅ ≡ᵉ ∅
+    res-∅ = dom-∅ res-dom
 
-  ∈-res : ∀ {a} {b : B} → (a , b) ∈ (R ∣ X) ⇔ ((a , b) ∈ R × a ∈ X)
-  ∈-res =
-    mk⇔ (λ ab∈ → (res-⊆ ab∈ , res-dom (to dom∈ (_ , ab∈))))
-        (to ∈-filter ∘ ×.swap)
+    res-∅ᶜ : {R : Rel A B} → R ∣ ∅ ᶜ ≡ᵉ R
+    res-∅ᶜ = ex-⊆ , λ a∈R → ∈⇔P (∉-∅ , a∈R)
 
-  ∈-resᶜ-dom⁻ : ∀ {a} → a ∈ dom (R ∣ X ᶜ) → a ∉ X × ∃[ b ] (a , b) ∈ R
-  ∈-resᶜ-dom⁻ a∈ = res-comp-dom a∈ , from dom∈ (dom⊆ ex-⊆ a∈)
+    ∈-res : {R : Rel A B} {X : Set A} → ∀ {a} {b : B} → (a , b) ∈ (R ∣ X) ⇔ ((a , b) ∈ R × a ∈ X)
+    ∈-res =
+      mk⇔ (λ ab∈ → (res-⊆ ab∈ , res-dom (to dom∈ (_ , ab∈))))
+          (to ∈-filter ∘ ×.swap)
 
-  ∈-resᶜ-dom⁺ : ∀ {a} → a ∉ X × ∃[ b ] (a , b) ∈ R → a ∈ dom (R ∣ X ᶜ)
-  ∈-resᶜ-dom⁺ (a∉X , (b , ab∈R)) = to dom∈ (b , (∈⇔P (a∉X , ab∈R)))
+    ∈-resᶜ-dom⁻ : {R : Rel A B} {X : Set A} → ∀ {a} → a ∈ dom (R ∣ X ᶜ) → a ∉ X × ∃[ b ] (a , b) ∈ R
+    ∈-resᶜ-dom⁻ a∈ = res-comp-dom a∈ , from dom∈ (dom⊆ ex-⊆ a∈)
 
-  ∈-resᶜ-dom : ∀ {a} → a ∈ dom (R ∣ X ᶜ) ⇔ (a ∉ X × ∃[ b ] (a , b) ∈ R)
-  ∈-resᶜ-dom = mk⇔ ∈-resᶜ-dom⁻ ∈-resᶜ-dom⁺
+    ∈-resᶜ-dom⁺ : {R : Rel A B} {X : Set A} → ∀ {a} → a ∉ X × ∃[ b ] (a , b) ∈ R → a ∈ dom (R ∣ X ᶜ)
+    ∈-resᶜ-dom⁺ (a∉X , (b , ab∈R)) = to dom∈ (b , (∈⇔P (a∉X , ab∈R)))
 
-  res-ex-∪ : Decidable (_∈ X) → (R ∣ X) ∪ (R ∣ X ᶜ) ≡ᵉ R
-  res-ex-∪ ∈X? = ∪-⊆ res-⊆ ex-⊆ , λ {a} h → case ∈X? (proj₁ a) of λ where
-    (yes p) → ∈⇔P (inj₁ (∈⇔P (p , h)))
-    (no ¬p) → ∈⇔P (inj₂ (∈⇔P (¬p , h)))
+    ∈-resᶜ-dom : {R : Rel A B} {X : Set A} → ∀ {a} → a ∈ dom (R ∣ X ᶜ) ⇔ (a ∉ X × ∃[ b ] (a , b) ∈ R)
+    ∈-resᶜ-dom = mk⇔ ∈-resᶜ-dom⁻ ∈-resᶜ-dom⁺
 
-  res-ex-disjoint : disjoint (dom (R ∣ X)) (dom (R ∣ X ᶜ))
-  res-ex-disjoint h h' = res-comp-dom h' (res-dom h)
+    res-ex-∪ : {R : Rel A B} {X : Set A} → Decidable (_∈ X) → (R ∣ X) ∪ (R ∣ X ᶜ) ≡ᵉ R
+    res-ex-∪ ∈X? = ∪-⊆ res-⊆ ex-⊆ , λ {a} h → case ∈X? (proj₁ a) of λ where
+      (yes p) → ∈⇔P (inj₁ (∈⇔P (p , h)))
+      (no ¬p) → ∈⇔P (inj₂ (∈⇔P (¬p , h)))
 
-  res-ex-disj-∪ : Decidable (_∈ X) → R ≡ (R ∣ X) ⨿ (R ∣ X ᶜ)
-  res-ex-disj-∪ ∈X? = IsEquivalence.sym ≡ᵉ-isEquivalence (res-ex-∪ ∈X?)
-                    , disjoint-dom⇒disjoint res-ex-disjoint
-    where open import Relation.Binary using (IsEquivalence)
+    res-ex-disjoint : {R : Rel A B} {X : Set A} → disjoint (dom (R ∣ X)) (dom (R ∣ X ᶜ))
+    res-ex-disjoint h h' = res-comp-dom h' (res-dom h)
 
-  curryʳ : Rel (A × B) C → A → Rel B C
-  curryʳ R a = mapˡ proj₂ (R ∣' (sp-∘ (sp-∈ {X = ❴ a ❵}) proj₁))
+    res-ex-disj-∪ : {R : Rel A B} {X : Set A} → Decidable (_∈ X) → R ≡ (R ∣ X) ⨿ (R ∣ X ᶜ)
+    res-ex-disj-∪ ∈X? = IsEquivalence.sym ≡ᵉ-isEquivalence (res-ex-∪ ∈X?)
+                      , disjoint-dom⇒disjoint res-ex-disjoint
+      where open import Relation.Binary using (IsEquivalence)
 
-  ∈-curryʳ : ∀ {a} {b : B} {c : C} → (b , c) ∈ curryʳ R a → ((a , b) , c) ∈ R
-  ∈-curryʳ h = case ∈⇔P h of λ where
-    (((a , b) , c) , refl , h'') → case ∈⇔P h'' of λ where
-      (p , p') → case from ∈-singleton p of λ where refl → p'
+    curryʳ : ⦃ _ : Cs C ⦄ → Rel (A × B) C → A → Rel B C
+    curryʳ R a = map (×.map₁ proj₂) (filter (sp-∘ (sp-∘ (sp-∈ {❴ a ❵}) proj₁) proj₁) R)
 
-  open Intersection sp-∈
-  open Intersectionᵖ sp-∈
+    ∈-curryʳ : ⦃ _ : Cs C ⦄ → ∀ {a} {b : B} {c : C} {R : Rel (A × B) C} → (b , c) ∈ curryʳ R a → ((a , b) , c) ∈ R
+    ∈-curryʳ h = case ∈⇔P h of λ where
+      (((a , b) , c) , refl , h'') → case ∈⇔P h'' of λ where
+        (p , p') → case from ∈-singleton p of λ where refl → p'
 
-  res-dom-comm⊆∩ : {m : Rel A B} {m' : Rel A C} → dom (m ∣ dom m') ⊆ dom m ∩ dom m'
-  res-dom-comm⊆∩ x = to ∈-∩ (res-domᵐ x , res-dom x)
+    open Intersection sp-∈
+    open Intersectionᵖ sp-∈
 
-  res-dom-comm∩⊆ : {m : Rel A B} {m' : Rel A C} → dom m ∩ dom m' ⊆ dom (m ∣ dom m')
-  res-dom-comm∩⊆ {m = m} {m' = m'} x with from ∈-∩ x
-  ... | a∈dm , a∈dm' with from dom∈ a∈dm | from dom∈ a∈dm'
-  ... | b , ab∈m | c , ac∈m = to dom∈ (b , to ∈-filter (a∈dm' , ab∈m))
+    module _ ⦃ _ : Cs C ⦄ where
+      private
+        domᶜ : Rel A C → Set A
+        domᶜ = map proj₁
 
-  res-dom-comm' : {m : Rel A B} {m' : Rel A C} → dom (m ∣ dom m') ≡ᵉ dom m ∩ dom m'
-  res-dom-comm' = res-dom-comm⊆∩ , res-dom-comm∩⊆
+        -- Restriction for Rel A C (can't reuse _∣_ which is fixed to Rel A B)
+        _∣ᶜ_ : Rel A C → Set A → Rel A C
+        m' ∣ᶜ X = filter (sp-∘ (sp-∈ {X}) proj₁) m'
 
-  res-dom-comm : {m : Rel A B} {m' : Rel A C} → dom (m ∣ dom m') ≡ᵉ dom (m' ∣ dom m)
-  res-dom-comm {m = m} {m'} = begin
-    dom (m ∣ dom m') ≈⟨ res-dom-comm' ⟩
-    dom m ∩ dom m'   ≈˘⟨ ∩-sym ⟩
-    dom m' ∩ dom m   ≈˘⟨ res-dom-comm' ⟩
-    dom (m' ∣ dom m) ∎
-    where open SetoidReasoning ≡ᵉ-Setoid
+      res-dom-comm⊆∩ : {m : Rel A B} {m' : Rel A C} → dom (m ∣ domᶜ m') ⊆ dom m ∩ domᶜ m'
+      res-dom-comm⊆∩ x = to ∈-∩ (res-domᵐ x , res-dom x)
 
-module Corestriction (sp-∈ : spec-∈ B) where
+      res-dom-comm∩⊆ : {m : Rel A B} {m' : Rel A C} → dom m ∩ domᶜ m' ⊆ dom (m ∣ domᶜ m')
+      res-dom-comm∩⊆ {m = m} {m' = m'} x with from ∈-∩ x
+      ... | a∈dm , a∈dm' with from dom∈ a∈dm | from dom∈ a∈dm'
+      ... | b , ab∈m | c , ac∈m = to dom∈ (b , to ∈-filter (a∈dm' , ab∈m))
 
-  _∣^_ : Rel A B → Set B → Rel A B
-  m ∣^ X = m ∣^' sp-∈ {X}
+      res-dom-comm' : {m : Rel A B} {m' : Rel A C} → dom (m ∣ domᶜ m') ≡ᵉ dom m ∩ domᶜ m'
+      res-dom-comm' = res-dom-comm⊆∩ , res-dom-comm∩⊆
 
-  _∣^_ᶜ : Rel A B → Set B → Rel A B
-  m ∣^ X ᶜ = m ∣^' sp-¬ (sp-∈ {X})
+      res-dom-comm : {m : Rel A B} {m' : Rel A C} → dom (m ∣ domᶜ m') ≡ᵉ domᶜ (m' ∣ᶜ dom m)
+      res-dom-comm {m = m} {m'} = fwd , bwd
+        where
+          fwd : dom (m ∣ domᶜ m') ⊆ domᶜ (m' ∣ᶜ dom m)
+          fwd x with from dom∈ (res-domᵐ x) | res-dom x
+          ... | b , ab∈m | a∈dm' with from dom∈ a∈dm'
+          ... | c , ac∈m' = to dom∈ (c , to ∈-filter (to dom∈ (b , ab∈m) , ac∈m'))
 
-  cores-⊆ : (R ∣^ X) ⊆ R
-  cores-⊆ = proj₂ ∘′ ∈⇔P
+          bwd : domᶜ (m' ∣ᶜ dom m) ⊆ dom (m ∣ domᶜ m')
+          bwd x with from ∈-map x
+          ... | p , refl , p∈filt with from ∈-filter p∈filt
+          ... | a∈dm , ac∈m' with from dom∈ a∈dm
+          ... | b , ab∈m = to dom∈ (b , to ∈-filter (to dom∈ (_ , ac∈m') , ab∈m))
 
-  coex-⊆ : (R ∣^ X ᶜ) ⊆ R
-  coex-⊆ = proj₂ ∘′ ∈⇔P
+  module Corestriction (sp-∈ : spec-∈ B) where
 
-  cores-cong : ∀ {R Q : Rel A B} {X Y : Set B}
-             → X ⊆ Y → R ⊆ Q
-             → R ∣^ X ⊆ Q ∣^ Y
-  cores-cong X⊆Y R⊆Y p with from ∈-filter p
-  ... | (q , p) = to ∈-filter (X⊆Y q , R⊆Y p)
+    _∣^_ : Rel A B → Set B → Rel A B
+    m ∣^ X = m ∣^' sp-∈ {X}
+
+    _∣^_ᶜ : Rel A B → Set B → Rel A B
+    m ∣^ X ᶜ = m ∣^' sp-¬ (sp-∈ {X})
+
+    cores-⊆ : {R : Rel A B} {X : Set B} → (R ∣^ X) ⊆ R
+    cores-⊆ = proj₂ ∘′ ∈⇔P
+
+    coex-⊆ : {R : Rel A B} {X : Set B} → (R ∣^ X ᶜ) ⊆ R
+    coex-⊆ = proj₂ ∘′ ∈⇔P
+
+    cores-cong : ∀ {R Q : Rel A B} {X Y : Set B}
+               → X ⊆ Y → R ⊆ Q
+               → R ∣^ X ⊆ Q ∣^ Y
+    cores-cong X⊆Y R⊆Y p with from ∈-filter p
+    ... | (q , p) = to ∈-filter (X⊆Y q , R⊆Y p)

--- a/src/Axiom/Set/SortedList.agda
+++ b/src/Axiom/Set/SortedList.agda
@@ -1,0 +1,142 @@
+{-# OPTIONS --safe --no-import-sorts #-}
+
+module Axiom.Set.SortedList where
+
+open import abstract-set-theory.Prelude
+
+open import Axiom.Set
+open import Class.HasOrder.Ext
+
+import Function.Related.Propositional as R
+import Relation.Nullary.Decidable as Dec
+
+open import Data.List as L
+open import Data.List.Membership.Propositional renaming (_∈_ to _∈ˡ_; find to ∈-find)
+open import Data.List.Membership.Propositional.Properties
+open import Data.List.Relation.Binary.Lex.NonStrict
+open import Data.List.Relation.Binary.Permutation.Propositional using (_↭_; ↭-sym)
+open import Data.List.Relation.Binary.Permutation.Propositional.Properties
+open import Data.List.Relation.Binary.Pointwise using (Pointwise-≡⇒≡; ≡⇒Pointwise-≡)
+open import Data.List.Relation.Unary.Sorted.TotalOrder.Properties
+open import Data.Product
+open import Relation.Binary.Bundles
+import Data.List.Sort
+import Data.List.Relation.Unary.Sorted.TotalOrder
+
+module SortedOps {A : Type} (ha : HDTO≡ A) where
+  private
+    O  = toDecTotalOrder ha
+    TO = DecTotalOrder.totalOrder O
+  open Data.List.Sort O using (sort; sort-↭; sort-↗)
+  open Data.List.Relation.Unary.Sorted.TotalOrder TO using (Sorted)
+
+  record SortedList : Type where
+    constructor mkSL
+    field
+      list : List A
+      .sorted : Sorted list
+  open SortedList public
+
+  _∈ˢ_ : A → SortedList → Type
+  a ∈ˢ sl = a ∈ˡ list sl
+
+  mkSorted : List A → SortedList
+  mkSorted l = mkSL (sort l) (sort-↗ l)
+
+  ∈-mkSorted⇔ : ∀ {a l} → a ∈ˡ l ⇔ a ∈ˢ mkSorted l
+  ∈-mkSorted⇔ {l = l} = mk⇔ (Any-resp-↭ (↭-sym (sort-↭ l))) (Any-resp-↭ (sort-↭ l))
+
+  filterˢ : ∀ {P : A → Type} → Decidable¹ P → SortedList → SortedList
+  filterˢ P? (mkSL l s) = mkSL (filter P? l) (filter⁺ TO P? s)
+
+------------------------------------------------------------------------
+-- The SortedList Model
+------------------------------------------------------------------------
+
+sorted-sc : SetConstraint {zeroˡ} {sucˡ zeroˡ}
+sorted-sc = record
+  { constraint = HDTO≡
+  ; c-×       = λ ca cb → mkCstr (HDTO≡-× (getCstr ca) (getCstr cb))
+  ; c-Maybe   = λ ca → mkCstr (HDTO≡-Maybe (getCstr ca))
+  }
+
+SL-≡ : ∀ {A} (ha : HDTO≡ A) {sl₁ sl₂ : SortedOps.SortedList ha}
+  → SortedOps.list sl₁ ≡ SortedOps.list sl₂ → sl₁ ≡ sl₂
+SL-≡ _ refl = refl
+
+module Helpers {A : Type} ⦃ ha : HDTO≡ A ⦄ where
+
+  module Inner = SortedOps ha
+
+  c-SortedList : HDTO≡ (SortedOps.SortedList ha)
+  c-SortedList = fromDecTotalOrder SL-dto id
+    where
+      module DTO = DecTotalOrder (≤-decTotalOrder (toDecTotalOrder ha))
+      open Inner using (SortedList; list)
+
+      SL-dto : DecTotalOrder 0ℓ 0ℓ 0ℓ
+      SL-dto = record
+        { Carrier = SortedList
+        ; _≈_ = _≡_
+        ; _≤_ = DTO._≤_ on list
+        ; isDecTotalOrder = record
+          { isTotalOrder = record
+            { isPartialOrder = record
+              { isPreorder = record
+                { isEquivalence = isEquivalence
+                ; reflexive = λ where refl → DTO.refl
+                ; trans     = DTO.trans
+                }
+              ; antisym = λ p q → SL-≡ ha (Pointwise-≡⇒≡ (DTO.antisym p q))
+              }
+            ; total = λ sl₁ sl₂ → DTO.total (list sl₁) (list sl₂)
+            }
+          ; _≟_ = λ sl₁ sl₂ → Dec.map
+                    (mk⇔ (λ p → SL-≡ ha (Pointwise-≡⇒≡ p))
+                         (λ where refl → ≡⇒Pointwise-≡ refl))
+                    (DTO._≟_ (list sl₁) (list sl₂))
+          ; _≤?_ = λ sl₁ sl₂ → DTO._≤?_ (list sl₁) (list sl₂)
+          }
+        }
+
+  module Outer = SortedOps c-SortedList
+
+  unions-helper : (X : Outer.SortedList) → Σ Inner.SortedList λ Y
+    → ∀ {a} → (∃[ T ] T Outer.∈ˢ X × a Inner.∈ˢ T) ⇔ a Inner.∈ˢ Y
+  unions-helper X = Inner.mkSorted (concat (L.map Inner.list (Outer.list X))) , λ {a} →
+    (∃[ T ] T ∈ˡ Outer.list X × a ∈ˡ Inner.list T)
+      ∼⟨ mk⇔ (λ (T , T∈X , a∈T) → ∈-concatMap⁺ Inner.list (lose T∈X a∈T))
+              (∈-find ∘ ∈-concatMap⁻ Inner.list) ⟩
+    a ∈ˡ concatMap Inner.list (Outer.list X)
+      ∼⟨ Inner.∈-mkSorted⇔ ⟩
+    a Inner.∈ˢ Inner.mkSorted (concat (L.map Inner.list (Outer.list X))) ∎
+    where open R.EquationalReasoning
+
+
+SortedList-Model : Theory {zeroˡ} {sucˡ zeroˡ}
+SortedList-Model = let open Helpers in record
+  { sc    = sorted-sc
+  ; Set   = λ A ⦃ ca ⦄ → SortedOps.SortedList (getCstr ca)
+  ; _∈_   = λ ⦃ ca ⦄ a sl → a ∈ˡ SortedOps.list sl
+  ; sp    = Dec-SpecProperty
+  ; c-Set = λ ⦃ ca ⦄ → mkCstr (c-SortedList ⦃ getCstr ca ⦄)
+  ; specification = λ ⦃ ca ⦄ X P? →
+      let open SortedOps (getCstr ca) in
+      filterˢ P? X , mk⇔
+        (λ where (Pa , a∈X) → ∈-filter⁺ P? a∈X Pa)
+        (λ a∈f → swap (∈-filter⁻ P? a∈f))
+  ; unions = λ ⦃ ca ⦄ X → unions-helper ⦃ getCstr ca ⦄ X
+  ; replacement = λ ⦃ ca ⦄ ⦃ cb ⦄ f X →
+      let module A = SortedOps (getCstr ca)
+          module B = SortedOps (getCstr cb)
+      in B.mkSorted (L.map f (A.list X)) , λ {b} → mk⇔
+        (λ where (a , refl , a∈X) → to B.∈-mkSorted⇔ (∈-map⁺ f a∈X))
+        (λ b∈Y → case ∈-map⁻ f (from B.∈-mkSorted⇔ b∈Y) of
+          λ where (a , a∈X , refl) → (a , refl , a∈X))
+  ; listing = λ ⦃ ca ⦄ l →
+      let open SortedOps (getCstr ca) in
+      mkSorted l , ∈-mkSorted⇔
+  }
+  where
+    open Theory hiding (filter)
+    open Equivalence

--- a/src/Axiom/Set/Sum.agda
+++ b/src/Axiom/Set/Sum.agda
@@ -4,7 +4,7 @@ open import Axiom.Set using (Theory)
 
 open import abstract-set-theory.Prelude hiding (ε)
 
-module Axiom.Set.Sum (th : Theory) where
+module Axiom.Set.Sum {ℓ_c} (th : Theory {zeroˡ} {ℓ_c}) where
 
 open Theory th
 open import Axiom.Set.Factor th
@@ -41,7 +41,6 @@ private macro
 
 private variable
   A B M : Type
-  X Y : Set A
   f : A → M
 
 module _ ⦃ M-commMonoid : CommutativeMonoid 0ℓ 0ℓ M ⦄ where
@@ -67,7 +66,7 @@ module _ ⦃ M-commMonoid : CommutativeMonoid 0ℓ 0ℓ M ⦄ where
     f y ∙ (f x ∙ indexedSumL f ys) ∎
   fold-cong↭ (trans h h₁) = ≈-trans (fold-cong↭ h) (fold-cong↭ h₁)
 
-  indexedSum : ⦃ _ : DecEq A ⦄ → (A → M) → FinSet A → M
+  indexedSum : ⦃ _ : Cs A ⦄ → ⦃ _ : DecEq A ⦄ → (A → M) → FinSet A → M
   indexedSum f = let open FactorUnique _≈_ (indexedSumL' f) fold-cong↭ in factor
 
   indexedSumL-++ : {l l' : List A}
@@ -85,7 +84,7 @@ module _ ⦃ M-commMonoid : CommutativeMonoid 0ℓ 0ℓ M ⦄ where
         f x ∙ indexedSumL f l ∙ m      ∎
 
 
-  module _ ⦃ _ : DecEq A ⦄ {f : A → M} where
+  module _ ⦃ _ : Cs A ⦄ ⦃ _ : DecEq A ⦄ {f : A → M} where
     open FactorUnique _≈_ (indexedSumL' f) fold-cong↭
 
     indexedSum-cong : indexedSum f Preserves (_≡ᵉ_ on proj₁) ⟶ _≈_
@@ -94,7 +93,7 @@ module _ ⦃ M-commMonoid : CommutativeMonoid 0ℓ 0ℓ M ⦄ where
     indexedSum-∅ : indexedSum f (∅ , ∅-finite) ≈ ε
     indexedSum-∅ = begin _ ∎
 
-    indexedSum-∪ : ⦃ Xᶠ : finite X ⦄ ⦃ Yᶠ : finite Y ⦄ → disjoint X Y
+    indexedSum-∪ : {X Y : Set A} → ⦃ Xᶠ : finite X ⦄ ⦃ Yᶠ : finite Y ⦄ → disjoint X Y
       → indexedSum f ((X ∪ Y) ᶠ) ≈ indexedSum f (X ᶠ) ∙ indexedSum f (Y ᶠ)
     indexedSum-∪ disj = factor-∪' {λ x y z → z ≈ x ∙ y} disj
         λ {l} disj' → ≈-trans (fold-cong↭ (dedup-++-↭ disj'))
@@ -110,7 +109,8 @@ module _ ⦃ M-commMonoid : CommutativeMonoid 0ℓ 0ℓ M ⦄ where
               indexedSum-singleton
       where module ≡ᵉ = IsEquivalence ≡ᵉ-isEquivalence
 
-module _ ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄ ⦃ _ : CommutativeMonoid 0ℓ 0ℓ M ⦄ where
+module _ ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄
+         ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄ ⦃ _ : CommutativeMonoid 0ℓ 0ℓ M ⦄ where
 
   indexedSumᵐ : (A × B → M) → FinMap A B → M
   indexedSumᵐ f (m , _ , h) = indexedSum f (m , h)
@@ -124,7 +124,8 @@ module _ ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄ ⦃ _ : CommutativeMonoid 0ℓ 
     → indexedSumᵐ f Preserves (_≡ᵉ_ on proj₁) ⟶ _≈_
   indexedSumᵐ-cong {x = x , _ , h} {y , _ , h'} = indexedSum-cong {x = x , h} {y , h'}
 
-module IndexedSumUnionᵐ ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄
+module IndexedSumUnionᵐ ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄
+  ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄
   (sp-∈ : spec-∈ A) (∈-A-dec : {X : Set A} → Decidable¹ (_∈ X)) where
 
   open Unionᵐ sp-∈

--- a/src/Axiom/Set/TotalMap.agda
+++ b/src/Axiom/Set/TotalMap.agda
@@ -2,7 +2,7 @@
 
 open import Axiom.Set using (Theory)
 
-module Axiom.Set.TotalMap (th : Theory) where
+module Axiom.Set.TotalMap {ℓ} {ℓ_c} (th : Theory {ℓ} {ℓ_c}) where
 
 open import abstract-set-theory.Prelude hiding (lookup; map)
 
@@ -13,13 +13,13 @@ open import Axiom.Set.Rel th            using (Rel ; dom ; dom∈)
 open Theory th
 open Equivalence
 
-private variable A B : Type
+private variable A B : Type ℓ
 
 -- defines a total map for a given set
-total : Rel A B → Type
+total : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → Rel A B → Type ℓ
 total R = ∀ {a} → a ∈ dom R
 
-record TotalMap (A B : Type) : Type where
+record TotalMap (A B : Type ℓ) ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄ : Type ℓ where
   field rel             : Set (A × B)
         left-unique-rel : left-unique rel
         total-rel       : total rel
@@ -40,7 +40,7 @@ record TotalMap (A B : Type) : Type where
 
 open TotalMap
 
-module Update ⦃ _ : DecEq A ⦄ where
+module Update ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄ ⦃ _ : DecEq A ⦄ where
 
   private
     updateFn : A × B → A → B → B
@@ -53,7 +53,7 @@ module Update ⦃ _ : DecEq A ⦄ where
   ... | yes _ = refl
   ... | no ¬p = ⊥-elim (¬p refl)
 
-  mapWithKey : {B' : Type} → (A → B → B') → TotalMap A B → TotalMap A B'
+  mapWithKey : {B' : Type ℓ} ⦃ _ : Cs B' ⦄ → (A → B → B') → TotalMap A B → TotalMap A B'
   mapWithKey f tm .rel              = map (λ{(x , y) → x , f x y}) (rel tm)
   mapWithKey _ tm .left-unique-rel  = mapWithKey-uniq (left-unique-rel tm)
   mapWithKey _ tm .total-rel        = ∈-map′ (∈-map′ (proj₂ (from dom∈ (total-rel tm))))
@@ -62,7 +62,8 @@ module Update ⦃ _ : DecEq A ⦄ where
   update a b = mapWithKey (updateFn (a , b))
 
 
-module LookupUpdate {X : Set A} {a : A} {b : B} {a∈X : a ∈ X} ⦃ _ : DecEq A ⦄ where
+module LookupUpdate ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄
+  {X : Set A} {a : A} {b : B} {a∈X : a ∈ X} ⦃ _ : DecEq A ⦄ where
 
   open Update
 
@@ -77,7 +78,8 @@ module LookupUpdate {X : Set A} {a : A} {b : B} {a∈X : a ∈ X} ⦃ _ : DecEq 
 ------------------------------------------------------
 -- Correspondences between total maps and functions --
 
-module FunTot (X : Set A) (⋁A≡X : isMaximal X) where
+module FunTot ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄
+  (X : Set A) (⋁A≡X : isMaximal X) where
 
   Fun⇒Map : ∀ {f : A → B} (X : Set A) → Map A B
   Fun⇒Map {f = f} X = map (λ x → (x , f x)) X , left-unique-mapˢ X

--- a/src/Axiom/Set/TotalMapOn.agda
+++ b/src/Axiom/Set/TotalMapOn.agda
@@ -2,7 +2,7 @@
 
 open import Axiom.Set using (Theory)
 
-module Axiom.Set.TotalMapOn (th : Theory) where
+module Axiom.Set.TotalMapOn {ℓ} {ℓ_c} (th : Theory {ℓ} {ℓ_c}) where
 
 open import abstract-set-theory.Prelude hiding (lookup; map)
 
@@ -10,16 +10,16 @@ open import Axiom.Set.Map th using (left-unique ; Map ; mapWithKey-uniq)
 open import Axiom.Set.Rel th using (Rel ; dom ; dom∈)
 open import Class.DecEq      using (DecEq ; _≟_)
 
-open Theory th    using ( Set ; _⊆_ ; _∈_ ; map ; ∈-map′ )
+open Theory th
 open Equivalence  using (from)
 
-private variable A B : Type
+private variable A B : Type ℓ
 
-_TotalOn_ : Rel A B → Set A → Type
+_TotalOn_ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → Rel A B → Set A → Type ℓ
 R TotalOn X = X ⊆ dom R
 
 
-record TotalMapOn {A : Type}(X : Set A)(B : Type) : Type where
+record TotalMapOn {A : Type ℓ} ⦃ _ : Cs A ⦄ (X : Set A) (B : Type ℓ) ⦃ _ : Cs B ⦄ : Type ℓ where
   field  rel              : Set (A × B)
          left-unique-rel  : left-unique rel
          total-rel        : rel TotalOn X
@@ -39,7 +39,7 @@ record TotalMapOn {A : Type}(X : Set A)(B : Type) : Type where
   rel⇒lookup {a} {a∈dom} ab∈rel = sym (left-unique-rel ab∈rel (proj₂ (from dom∈ (total-rel a∈dom))))
 
 
-module UpdateOn {B : Type} ⦃ _ : DecEq A ⦄ where
+module UpdateOn {B : Type ℓ} ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄ ⦃ _ : DecEq A ⦄ where
 
   private
     updateFn : A × B → A → B → B
@@ -49,7 +49,7 @@ module UpdateOn {B : Type} ⦃ _ : DecEq A ⦄ where
 
   open TotalMapOn
 
-  mapWithKeyOn : {X : Set A}{B' : Type} → (A → B → B') → TotalMapOn X B → TotalMapOn X B'
+  mapWithKeyOn : {X : Set A}{B' : Type ℓ} ⦃ _ : Cs B' ⦄ → (A → B → B') → TotalMapOn X B → TotalMapOn X B'
   mapWithKeyOn f tm .rel              = map (λ{(x , y) → x , f x y}) (rel tm)
   mapWithKeyOn _ tm .left-unique-rel  = mapWithKey-uniq (left-unique-rel tm)
   mapWithKeyOn _ tm .total-rel a∈X    = ∈-map′ (∈-map′ (proj₂ (from dom∈ ((total-rel tm) a∈X))))

--- a/src/Class/HasEmptySet.agda
+++ b/src/Class/HasEmptySet.agda
@@ -2,22 +2,24 @@
 
 open import Axiom.Set using (Theory)
 
-module Class.HasEmptySet (th : Theory) where
+module Class.HasEmptySet {ℓ} {ℓ_c} (th : Theory {ℓ} {ℓ_c}) where
 
 open import abstract-set-theory.Prelude
 
 open Theory th renaming (∅ to ∅ˢ)
 open import Axiom.Set.Map th
 
-record HasEmptySet (A : Type) : Type where
+private variable A B : Type ℓ
+
+record HasEmptySet (A : Type ℓ) : Type ℓ where
   field
     ∅ : A
 
 open HasEmptySet ⦃...⦄ public
 
 instance
-  HasEmptySet-Set : {A : Type} → HasEmptySet (Set A)
+  HasEmptySet-Set : ⦃ _ : Cs A ⦄ → HasEmptySet (Set A)
   HasEmptySet-Set = record { ∅ = ∅ˢ }
 
-  HasEmptySet-Map : {A B : Type} → HasEmptySet (Map A B)
+  HasEmptySet-Map : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → HasEmptySet (Map A B)
   HasEmptySet-Map = record { ∅ = ∅ᵐ }

--- a/src/Class/HasOrder/Ext.agda
+++ b/src/Class/HasOrder/Ext.agda
@@ -1,0 +1,233 @@
+{-# OPTIONS --safe --no-import-sorts #-}
+
+-- Extensions to Class.HasOrder: conversions between HasDecTotalOrder≡
+-- and DecTotalOrder, a Maybe ordering, and closure of HDTO≡ under
+-- common type constructors (×, Maybe, List).
+
+module Class.HasOrder.Ext where
+
+open import abstract-set-theory.Prelude
+
+open import Class.HasOrder
+  using (HasDecTotalOrder; HasTotalOrder; HasPartialOrder; HasPreorder;
+         HasDecTotalOrder≡)
+open import Class.HasOrder.Core
+  using (hasPreorderFromNonStrict; hasPartialOrderFromNonStrict)
+
+open import Relation.Binary
+  using (Antisymmetric; IsDecTotalOrder; IsPreorder; IsTotalOrder; IsPartialOrder;
+         IsEquivalence)
+  renaming (Decidable to Dec₂)
+open import Relation.Binary.Bundles using (DecTotalOrder)
+
+private variable
+  A B : Type
+
+------------------------------------------------------------------------
+-- Conversions between HDTO≡ and DecTotalOrder
+------------------------------------------------------------------------
+
+HDTO≡ : Type → Type₁
+HDTO≡ A = HasDecTotalOrder≡ {A = A} {zeroˡ} {zeroˡ}
+
+-- Convert HasDecTotalOrder≡ to a DecTotalOrder bundle.
+-- Derives DecEq from antisymmetry + decidable ≤.
+toDecTotalOrder : HDTO≡ A → DecTotalOrder 0ℓ 0ℓ 0ℓ
+toDecTotalOrder {A} hdto = record
+  { Carrier         = A
+  ; _≈_             = _≡_
+  ; _≤_             = HasPreorder._≤_ hp
+  ; isDecTotalOrder = record
+    { isTotalOrder = HasTotalOrder.≤-isTotalOrder ht
+    ; _≟_          = _≟ᵒ_
+    ; _≤?_         = _≤ᵒ?_
+    }
+  }
+  where
+    ht  = HasDecTotalOrder.hasTotalOrder hdto
+    hpo = HasTotalOrder.hasPartialOrder ht
+    hp  = HasPartialOrder.hasPreorder hpo
+    _≤ᵒ?_ : Dec₂ (HasPreorder._≤_ hp)
+    _≤ᵒ?_ = dec² ⦃ HasDecTotalOrder.dec-≤ hdto ⦄
+
+    _≟ᵒ_ : Dec₂ (_≡_ {A = A})
+    _≟ᵒ_ x y with x ≤ᵒ? y | y ≤ᵒ? x
+    ... | yes x≤y | yes y≤x = yes (HasPartialOrder.≤-antisym hpo x≤y y≤x)
+    ... | yes _   | no  y≰x = no (λ where refl → y≰x (HasPreorder.≤-refl hp))
+    ... | no  x≰y | _       = no (λ where refl → x≰y (HasPreorder.≤-refl hp))
+
+-- Convert a DecTotalOrder back to HDTO≡,
+-- given a proof that the bundle's _≈_ implies propositional equality.
+fromDecTotalOrder : (dto : DecTotalOrder 0ℓ 0ℓ 0ℓ) →
+  (∀ {x y} → DecTotalOrder._≈_ dto x y → x ≡ y) →
+  HDTO≡ (DecTotalOrder.Carrier dto)
+fromDecTotalOrder dto ≈⇒≡ = record
+  { hasTotalOrder = record
+    { hasPartialOrder = hpo
+    ; ≤-total = IsTotalOrder.total (IsDecTotalOrder.isTotalOrder idto)
+    }
+  ; dec-≤ = ⁇² IsDecTotalOrder._≤?_ idto
+  ; dec-< = ⁇² dec-<′
+  }
+  where
+    open DecTotalOrder dto using (Carrier; _≈_) renaming (_≤_ to _≤d_)
+    idto = DecTotalOrder.isDecTotalOrder dto
+    ipo = IsTotalOrder.isPartialOrder (IsDecTotalOrder.isTotalOrder idto)
+    ipre = IsPartialOrder.isPreorder ipo
+
+    ≡-isPreorder : IsPreorder _≡_ _≤d_
+    ≡-isPreorder = record
+      { isEquivalence = isEquivalence
+      ; reflexive     = λ where refl → IsPreorder.refl ipre
+      ; trans         = IsPreorder.trans ipre
+      }
+
+    _≟d_ : Dec₂ (_≡_ {A = Carrier})
+    _≟d_ x y with IsDecTotalOrder._≟_ idto x y
+    ... | yes x≈y = yes (≈⇒≡ x≈y)
+    ... | no  x≉y = no (λ where refl → x≉y (IsEquivalence.refl (IsPreorder.isEquivalence ipre)))
+
+    hp : HasPreorder
+    hp = hasPreorderFromNonStrict ≡-isPreorder _≟d_
+
+    antisym-≡ : Antisymmetric _≡_ _≤d_
+    antisym-≡ x≤y y≤x = ≈⇒≡ (IsPartialOrder.antisym ipo x≤y y≤x)
+
+    hpo : HasPartialOrder
+    hpo = hasPartialOrderFromNonStrict ≡-isPreorder _≟d_ antisym-≡
+
+    open import Relation.Binary.Construct.NonStrictToStrict _≡_ _≤d_ as SNS
+
+    dec-<′ : Dec₂ SNS._<_
+    dec-<′ x y with IsDecTotalOrder._≤?_ idto x y | _≟d_ x y
+    ... | yes x≤y | yes x≡y = no (λ (x≤y' , x≢y) → x≢y x≡y)
+    ... | yes x≤y | no  x≢y = yes (x≤y , x≢y)
+    ... | no  x≰y | _       = no (λ (x≤y , _) → x≰y x≤y)
+
+------------------------------------------------------------------------
+-- DecTotalOrder on Maybe: nothing ≤ everything, just x ≤ just y ↔ x ≤ y
+------------------------------------------------------------------------
+
+module MaybeOrder where
+
+  data _≤ᴹ_ {A : Type} (R : A → A → Type) : Maybe A → Maybe A → Type where
+    nothing≤   : ∀ {x} → _≤ᴹ_ R nothing x
+    just≤just  : ∀ {x y} → R x y → _≤ᴹ_ R (just x) (just y)
+
+  module _ {A : Type} {_≤d_ : A → A → Type}
+           (≤-refl′ : ∀ {x} → x ≤d x)
+           (≤-trans′ : ∀ {x y z} → x ≤d y → y ≤d z → x ≤d z) where
+
+    ≤ᴹ-refl : ∀ {x} → _≤ᴹ_ _≤d_ x x
+    ≤ᴹ-refl {nothing} = nothing≤
+    ≤ᴹ-refl {just _}  = just≤just ≤-refl′
+
+    ≤ᴹ-trans : ∀ {x y z} → _≤ᴹ_ _≤d_ x y → _≤ᴹ_ _≤d_ y z → _≤ᴹ_ _≤d_ x z
+    ≤ᴹ-trans nothing≤       _               = nothing≤
+    ≤ᴹ-trans (just≤just p)  (just≤just q)   = just≤just (≤-trans′ p q)
+
+  module _ {A : Type} {_≤d_ : A → A → Type}
+           (≤-antisym′ : ∀ {x y} → x ≤d y → y ≤d x → x ≡ y) where
+
+    ≤ᴹ-antisym : ∀ {x y} → _≤ᴹ_ _≤d_ x y → _≤ᴹ_ _≤d_ y x → x ≡ y
+    ≤ᴹ-antisym nothing≤       nothing≤       = refl
+    ≤ᴹ-antisym (just≤just p)  (just≤just q)  = cong just (≤-antisym′ p q)
+
+  module _ {A : Type} {_≤d_ : A → A → Type}
+           (≤-total′ : ∀ x y → x ≤d y ⊎ y ≤d x) where
+
+    ≤ᴹ-total : ∀ x y → _≤ᴹ_ _≤d_ x y ⊎ _≤ᴹ_ _≤d_ y x
+    ≤ᴹ-total nothing  _        = inj₁ nothing≤
+    ≤ᴹ-total _        nothing  = inj₂ nothing≤
+    ≤ᴹ-total (just x) (just y) with ≤-total′ x y
+    ... | inj₁ x≤y = inj₁ (just≤just x≤y)
+    ... | inj₂ y≤x = inj₂ (just≤just y≤x)
+
+  module _ {A : Type} {_≤d_ : A → A → Type}
+           (≤-dec′ : ∀ x y → Dec (x ≤d y)) where
+
+    ≤ᴹ-dec : ∀ x y → Dec (_≤ᴹ_ _≤d_ x y)
+    ≤ᴹ-dec nothing  _        = yes nothing≤
+    ≤ᴹ-dec (just x) nothing  = no (λ ())
+    ≤ᴹ-dec (just x) (just y) with ≤-dec′ x y
+    ... | yes x≤y = yes (just≤just x≤y)
+    ... | no  x≰y = no  (λ where (just≤just p) → x≰y p)
+
+Maybe-decTotalOrder : (dto : DecTotalOrder 0ℓ 0ℓ 0ℓ)
+  → DecTotalOrder.Carrier dto ≡ A
+  → (∀ {x y} → DecTotalOrder._≈_ dto x y → x ≡ y)
+  → DecTotalOrder 0ℓ 0ℓ 0ℓ
+Maybe-decTotalOrder {A} dto refl ≈⇒≡ = record
+  { Carrier = Maybe A
+  ; _≈_ = _≡_
+  ; _≤_ = _≤ᴹ_ _≤d_
+  ; isDecTotalOrder = record
+    { isTotalOrder = record
+      { isPartialOrder = record
+        { isPreorder = record
+          { isEquivalence = isEquivalence
+          ; reflexive     = λ where refl → ≤ᴹ-refl ≤-refl ≤-trans
+          ; trans         = ≤ᴹ-trans ≤-refl ≤-trans
+          }
+        ; antisym = ≤ᴹ-antisym (λ p q → ≈⇒≡ (antisym p q))
+        }
+      ; total = ≤ᴹ-total total
+      }
+    ; _≟_  = ≟ᴹ
+    ; _≤?_ = ≤ᴹ-dec _≤?d_
+    }
+  }
+  where
+    open MaybeOrder
+    open DecTotalOrder dto using () renaming (_≤_ to _≤d_; _≤?_ to _≤?d_)
+    open DecTotalOrder dto using (isDecTotalOrder)
+    open IsDecTotalOrder isDecTotalOrder using (total) renaming (_≟_ to _≟d'_)
+    open IsDecTotalOrder isDecTotalOrder
+      using () renaming (isPartialOrder to ipo)
+    open IsPartialOrder ipo using (antisym)
+    open IsPreorder (IsPartialOrder.isPreorder ipo)
+      using () renaming (refl to ≤-refl; trans to ≤-trans)
+
+    ≈-refl′ : ∀ {x : A} → DecTotalOrder._≈_ dto x x
+    ≈-refl′ = IsEquivalence.refl (IsPreorder.isEquivalence (IsPartialOrder.isPreorder ipo))
+
+    ≟d : (x y : A) → Dec (x ≡ y)
+    ≟d x y with _≟d'_ x y
+    ... | yes p = yes (≈⇒≡ p)
+    ... | no ¬p = no λ where refl → ¬p ≈-refl′
+
+    ≟ᴹ : Dec₂ (_≡_ {A = Maybe A})
+    ≟ᴹ nothing  nothing  = yes refl
+    ≟ᴹ nothing  (just _) = no (λ ())
+    ≟ᴹ (just _) nothing  = no (λ ())
+    ≟ᴹ (just x) (just y) with ≟d x y
+    ... | yes refl = yes refl
+    ... | no  x≢y = no (λ where refl → x≢y refl)
+
+------------------------------------------------------------------------
+-- HDTO≡ closures for common type constructors
+------------------------------------------------------------------------
+
+open import Data.Product.Relation.Binary.Lex.NonStrict
+  using (×-decTotalOrder)
+open import Data.List.Relation.Binary.Lex.NonStrict
+  using (≤-decTotalOrder)
+open import Data.Product.Relation.Binary.Pointwise.NonDependent
+  using (≡×≡⇒≡)
+open import Data.List.Relation.Binary.Pointwise
+  using (Pointwise-≡⇒≡)
+
+HDTO≡-× : HDTO≡ A → HDTO≡ B → HDTO≡ (A × B)
+HDTO≡-× ha hb = fromDecTotalOrder
+  (×-decTotalOrder (toDecTotalOrder ha) (toDecTotalOrder hb))
+  ≡×≡⇒≡
+
+HDTO≡-Maybe : HDTO≡ A → HDTO≡ (Maybe A)
+HDTO≡-Maybe ha = fromDecTotalOrder
+  (Maybe-decTotalOrder (toDecTotalOrder ha) refl id)
+  id
+
+HDTO≡-List : HDTO≡ A → HDTO≡ (List A)
+HDTO≡-List ha = fromDecTotalOrder
+  (≤-decTotalOrder (toDecTotalOrder ha))
+  Pointwise-≡⇒≡

--- a/src/Class/HasSingleton.agda
+++ b/src/Class/HasSingleton.agda
@@ -2,22 +2,24 @@
 
 open import Axiom.Set using (Theory)
 
-module Class.HasSingleton (th : Theory) where
+module Class.HasSingleton {ℓ} {ℓ_c} (th : Theory {ℓ} {ℓ_c}) where
 
 open Theory th renaming (Set to ℙ_; ❴_❵ to ❴_❵ˢ)
 
 open import Axiom.Set.Map th
 open import abstract-set-theory.Prelude
 
-record HasSingleton (A B : Type) : Type where
+private variable A B : Type ℓ
+
+record HasSingleton (A B : Type ℓ) : Type ℓ where
   field
     ❴_❵ : A → B
 
 open HasSingleton ⦃...⦄ public
 
 instance
-  HasSingletonSet-Set : {A : Type} → HasSingleton A (ℙ A)
+  HasSingletonSet-Set : ⦃ _ : Cs A ⦄ → HasSingleton A (ℙ A)
   HasSingletonSet-Set = record { ❴_❵ = ❴_❵ˢ }
 
-  HasSingletonSet-Map : {A B : Type} → HasSingleton (A × B) (Map A B)
+  HasSingletonSet-Map : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → HasSingleton (A × B) (Map A B)
   HasSingletonSet-Map = record { ❴_❵ = ❴_❵ᵐ }

--- a/src/Class/IsSet.agda
+++ b/src/Class/IsSet.agda
@@ -2,7 +2,7 @@
 
 open import Axiom.Set
 
-module Class.IsSet (th : Theory) where
+module Class.IsSet {ℓ} {ℓ_c} (th : Theory {ℓ} {ℓ_c}) where
 
 open Theory th renaming (_∈_ to _∈ᵗ_; _∉_ to _∉ᵗ_)
 
@@ -12,9 +12,9 @@ open import Axiom.Set.TotalMap th as TotalMap
 open import Data.Product
 open import abstract-set-theory.Prelude
 
-private variable A B X : Type
+private variable A B X : Type ℓ
 
-record IsSet (A B : Type) : Type where
+record IsSet (A : Type ℓ) (B : Type ℓ) ⦃ _ : Cs B ⦄ : Type ℓ where
   field
     toSet : A → Set B
 
@@ -26,16 +26,16 @@ record IsSet (A B : Type) : Type where
 open IsSet ⦃...⦄ public
 
 infix 2 All-syntax
-All-syntax : ∀ {A X} ⦃ _ : IsSet X A ⦄ → (A → Type) → X → Type
+All-syntax : ∀ {A X} ⦃ _ : Cs A ⦄ ⦃ _ : IsSet X A ⦄ → (A → Type) → X → Type ℓ
 All-syntax P X = All P (toSet X)
 syntax All-syntax (λ x → P) l = ∀[ x ∈ l ] P
 
 infix 2 Ex-syntax
-Ex-syntax : ∀ {A X} ⦃ _ : IsSet X A ⦄ → (A → Type) → X → Type
+Ex-syntax : ∀ {A X} ⦃ _ : Cs A ⦄ ⦃ _ : IsSet X A ⦄ → (A → Type) → X → Type ℓ
 Ex-syntax P X = Any P (toSet X)
 syntax Ex-syntax (λ x → P) l = ∃[ x ∈ l ] P
 
-module _ ⦃ _ : IsSet X (A × B) ⦄ where
+module _ ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄ ⦃ _ : IsSet X (A × B) ⦄ where
   dom : X → Set A
   dom = Rel.dom ∘ toSet
 
@@ -43,11 +43,11 @@ module _ ⦃ _ : IsSet X (A × B) ⦄ where
   range = Rel.range ∘ toSet
 
 instance
-  IsSet-Set : IsSet (Set A) A
+  IsSet-Set : ⦃ _ : Cs A ⦄ → IsSet (Set A) A
   IsSet-Set .toSet A = A
 
-  IsSet-Map : IsSet (Map A B) (A × B)
+  IsSet-Map : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → IsSet (Map A B) (A × B)
   IsSet-Map .toSet = _ˢ
 
-  IsSet-TotalMap : IsSet (TotalMap A B) (A × B)
+  IsSet-TotalMap : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → IsSet (TotalMap A B) (A × B)
   IsSet-TotalMap .toSet = TotalMap.rel

--- a/src/abstract-set-theory/FiniteSetTheory.agda
+++ b/src/abstract-set-theory/FiniteSetTheory.agda
@@ -10,11 +10,11 @@ open import Axiom.Set
 open import Relation.Binary using (_Preserves_⟶_)
 
 opaque
-  List-Model : Theory {0ℓ}
+  List-Model : Theory {0ℓ} {0ℓ}
   List-Model = L.List-Model
-  List-Modelᶠ : Theoryᶠ
+  List-Modelᶠ : Theoryᶠ {0ℓ}
   List-Modelᶠ = L.List-Modelᶠ
-  List-Modelᵈ : Theoryᵈ
+  List-Modelᵈ : Theoryᵈ {0ℓ}
   List-Modelᵈ = L.List-Modelᵈ
 
 private variable
@@ -43,77 +43,82 @@ open import Axiom.Set.Properties th using (card-≡ᵉ)
 
 infixr 9 _∘ʳ_
 
-module _ ⦃ _ : DecEq A ⦄ where
-  open Restriction {A} ∈-sp public
+module _ ⦃ _ : Cs A ⦄ ⦃ _ : DecEq A ⦄ where
+  private module R' {B} ⦃ _ : Cs B ⦄ = Restriction {A} {B} ∈-sp
+  open R' public
     renaming (_∣_ to _∣ʳ_; _∣_ᶜ to _∣ʳ_ᶜ)
 
-  open Corestriction {A} ∈-sp public
-    renaming (_∣^_ to _∣^ʳ_; _∣^_ᶜ to _∣^ʳ_ᶜ) public
+  private module CR' {B} ⦃ _ : Cs B ⦄ ⦃ _ : DecEq B ⦄ = Corestriction {A} {B} (∈-sp {B})
+  open CR' public
+    renaming (_∣^_ to _∣^ʳ_; _∣^_ᶜ to _∣^ʳ_ᶜ)
 
-  open Restrictionᵐ {A} ∈-sp
-    renaming (res-cong to resᵐ-cong) public
-  open Corestrictionᵐ {A} ∈-sp
-    renaming (cores-cong to coresᵐ-cong) public
+  private module Rᵐ' {B} ⦃ _ : Cs B ⦄ = Restrictionᵐ {A} {B} ∈-sp
+  open Rᵐ' public
+    renaming (res-cong to resᵐ-cong)
+
+  private module CRᵐ' {B} ⦃ _ : Cs B ⦄ ⦃ _ : DecEq B ⦄ = Corestrictionᵐ {A} {B} (∈-sp {B})
+  open CRᵐ' public
+    renaming (cores-cong to coresᵐ-cong)
+
   open Unionᵐ {A} ∈-sp public
   open Intersection {A} ∈-sp public
-  open Lookupᵐ {A} ∈-sp public
   open Lookupᵐᵈ {A} ∈-sp public
 
-module _ ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄ where
+module _ ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄ ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄ where
   open Intersectionᵐ {A} {B} ∈-sp public
   open IndexedSumUnionᵐ {A} {B} ∈-sp (_∈? _) public
 
 module Properties where
   open import Axiom.Set.Properties th public
-  module _ ⦃ _ : DecEq A ⦄ where
+  module _ ⦃ _ : Cs A ⦄ ⦃ _ : DecEq A ⦄ where
     open Intersectionᵖ {A} ∈-sp public
 
 opaque
-  unfolding List-Model
+  unfolding List-Model List-Modelᶠ List-Modelᵈ
 
   to-sp : {A : Type} (P : A → Type) → ⦃ P ⁇¹ ⦄ → specProperty P
   to-sp _ = dec¹
 
-  finiteness : ∀ (X : Theory.Set th A) → finite X
+  finiteness : ⦃ _ : Cs A ⦄ → ∀ (X : Theory.Set th A) → finite X
   finiteness = Theoryᶠ.finiteness List-Modelᶠ
 
-  lengthˢ : ∀ {𝕊} ⦃ _ : DecEq A ⦄ ⦃ _ : IsSet 𝕊 A ⦄ → 𝕊 → ℕ
+  lengthˢ : ∀ {𝕊} ⦃ _ : Cs A ⦄ ⦃ _ : DecEq A ⦄ ⦃ _ : IsSet 𝕊 A ⦄ → 𝕊 → ℕ
   lengthˢ X = Theoryᶠ.lengthˢ List-Modelᶠ (toSet X)
 
-  lengthˢ-≡ᵉ :  ∀ {𝕊} ⦃ _ : DecEq A ⦄ ⦃ _ : IsSet 𝕊 A ⦄ → (X Y : 𝕊)
+  lengthˢ-≡ᵉ :  ∀ {𝕊} ⦃ _ : Cs A ⦄ ⦃ _ : DecEq A ⦄ ⦃ _ : IsSet 𝕊 A ⦄ → (X Y : 𝕊)
     → toSet X ≡ᵉ toSet Y
     → lengthˢ X ≡ lengthˢ Y
   lengthˢ-≡ᵉ X Y X≡Y =
     card-≡ᵉ (-, Theoryᶠ.DecEq⇒strongly-finite List-Modelᶠ (toSet X))
             (-, Theoryᶠ.DecEq⇒strongly-finite List-Modelᶠ (toSet Y)) X≡Y
 
-  setToList : ℙ A → List A
+  setToList : ⦃ _ : Cs A ⦄ → ℙ A → List A
   setToList = id
 
   instance
-    DecEq-ℙ : ⦃ _ : DecEq A ⦄ → DecEq (ℙ A)
+    DecEq-ℙ : ⦃ _ : Cs A ⦄ → ⦃ _ : DecEq A ⦄ → DecEq (ℙ A)
     DecEq-ℙ = L.Decˡ.DecEq-Set
 
-    Show-ℙ : ⦃ _ : Show A ⦄ → Show (ℙ A)
+    Show-ℙ : ⦃ _ : Cs A ⦄ → ⦃ _ : Show A ⦄ → Show (ℙ A)
     Show-ℙ .show = λ x → Show-finite .show (x , (finiteness x))
 
-_ᶠᵐ : A ⇀ B → FinMap A B
+_ᶠᵐ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → A ⇀ B → FinMap A B
 (R , uniq) ᶠᵐ = (R , uniq , finiteness _)
 
-_ᶠˢ : ℙ A → FinSet A
+_ᶠˢ : ⦃ _ : Cs A ⦄ → ℙ A → FinSet A
 X ᶠˢ = X , finiteness _
 
-filterˢ : (P : A → Type) ⦃ _ : P ⁇¹ ⦄ → ℙ A → ℙ A
+filterˢ : ⦃ _ : Cs A ⦄ → (P : A → Type) ⦃ _ : P ⁇¹ ⦄ → ℙ A → ℙ A
 filterˢ P = filterˢ? (to-sp P)
 
 -- [ R ∘ʳ S ] = { (a , c) | ∃ b → (a , b) ∈ R × (b , c) ∈ S }
-_∘ʳ_ : {A B C : Type} ⦃ _ : DecEq B ⦄ → Rel A B → Rel B C → Rel A C
+_∘ʳ_ : {A B C : Type} ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄ ⦃ _ : Cs C ⦄ ⦃ _ : DecEq B ⦄ → Rel A B → Rel B C → Rel A C
 R ∘ʳ S =
   concatMapˢ
     (λ (a , b) → mapˢ ((a ,_) ∘ proj₂) $ filterˢ ((b ≡_) ∘ proj₁) S)
     R
 
-module _ {A B C : Type} ⦃ _ : DecEq B ⦄ {R R' : Rel A B} {S S' : Rel B C} where
+module _ {A B C : Type} ⦃ _ : Cs A ⦄ ⦃ _ : Cs B ⦄ ⦃ _ : Cs C ⦄ ⦃ _ : DecEq B ⦄ {R R' : Rel A B} {S S' : Rel B C} where
 
   open Equivalence
 
@@ -132,29 +137,29 @@ module _ {A B C : Type} ⦃ _ : DecEq B ⦄ {R R' : Rel A B} {S S' : Rel B C} wh
           ... | _ , refl , p with from ∈-filter p
           ... | (p , q) = to ∈-concatMapˢ (a , R≡R' .proj₂ a∈R , to ∈-map (_ , (refl , to ∈-filter (p , S≡S' .proj₂ q))))
 
-filterᵐ : (P : A × B → Type) ⦃ _ : P ⁇¹ ⦄ → (A ⇀ B) → (A ⇀ B)
+filterᵐ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → (P : A × B → Type) ⦃ _ : P ⁇¹ ⦄ → (A ⇀ B) → (A ⇀ B)
 filterᵐ P = filterᵐ? (to-sp P)
 
-filterKeys : (P : A → Type) ⦃ _ : P ⁇¹ ⦄ → (A ⇀ B) → (A ⇀ B)
+filterKeys : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → (P : A → Type) ⦃ _ : P ⁇¹ ⦄ → (A ⇀ B) → (A ⇀ B)
 filterKeys P = filterKeys? (to-sp P)
 
-_∣^'_ : A ⇀ B → (P : B → Type) ⦃ _ : P ⁇¹ ⦄ → A ⇀ B
+_∣^'_ : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → A ⇀ B → (P : B → Type) ⦃ _ : P ⁇¹ ⦄ → A ⇀ B
 s ∣^' P = s ∣^'? to-sp P
 
-indexedSumᵛ' : ⦃ DecEq A ⦄ → ⦃ DecEq B ⦄ → ⦃ CommutativeMonoid 0ℓ 0ℓ C ⦄ → (B → C) → A ⇀ B → C
+indexedSumᵛ' : ⦃ _ : Cs A ⦄ → ⦃ _ : Cs B ⦄ → ⦃ DecEq A ⦄ → ⦃ DecEq B ⦄ → ⦃ CommutativeMonoid 0ℓ 0ℓ C ⦄ → (B → C) → A ⇀ B → C
 indexedSumᵛ' f m = indexedSumᵛ f (m ᶠᵐ)
 
-indexedSum' : ⦃ DecEq A ⦄ → ⦃ CommutativeMonoid 0ℓ 0ℓ B ⦄ → (A → B) → ℙ A → B
+indexedSum' : ⦃ _ : Cs A ⦄ → ⦃ DecEq A ⦄ → ⦃ CommutativeMonoid 0ℓ 0ℓ B ⦄ → (A → B) → ℙ A → B
 indexedSum' f s = indexedSum f (s ᶠˢ)
 
 syntax indexedSumᵛ' (λ a → x) m = ∑[ a ← m ] x
 syntax indexedSum'  (λ a → x) m = ∑ˢ[ a ← m ] x
 
-module _ ⦃ _ : DecEq A ⦄ ⦃ _ : CommutativeMonoid 0ℓ 0ℓ C ⦄ where
+module _ ⦃ _ : Cs A ⦄ ⦃ _ : Cs C ⦄ ⦃ _ : DecEq A ⦄ ⦃ _ : CommutativeMonoid 0ℓ 0ℓ C ⦄ where
 
   open CommutativeMonoid it
 
-  module _ ⦃ _ : DecEq B ⦄ where
+  module _ ⦃ _ : Cs B ⦄ ⦃ _ : DecEq B ⦄ where
 
     aggregateBy : ⦃ DecEq C ⦄ → Rel A B → A ⇀ C → B ⇀ C
     aggregateBy R m =


### PR DESCRIPTION
This is mostly relevant for performance. We now have a `SortedList` model that allows for more efficient set operations. This also opens the door for a tree-based model or a FFI model via the Haskell `containers` library.

One annoying thing is that `variable` seems to not be able to handle instance constraints in the way we'd like, so there are now lots of explicit constraints everywhere. While it is possible to have `instance` variables, they seem to only be in scope for other things within a `variable` block. Maybe this gets better in 2.9?

`module` blocks can help with this issue, but then we need to be really careful to not accidentally have a function in a module that doesn't need all the constraints provided by it.